### PR TITLE
Hotfix/http status code

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -88,6 +88,8 @@ groups:
     - build and release
     - pullrequest
     - deploy-to-staging
+    - Do final release and deploy live
+    - deploy-to-live
 
 - name: Pullrequest
   jobs:
@@ -102,6 +104,7 @@ groups:
 - name: Live
   jobs:
     - Do final release and deploy live
+    - deploy-to-live
 
 ###############################
 # Jobs
@@ -283,4 +286,4 @@ jobs:
       TAR_FILE: automation-release/automation-artifcat.tar.gz
       CI_INVENTORY: "live.ini"
       GROUP_NAME: "ops-gateway"
-      VERSION_FILE: 'gh-release-rc/version'
+      VERSION_FILE: 'gh-release-final/version'

--- a/middleware.go
+++ b/middleware.go
@@ -27,7 +27,6 @@ func CreateMiddleware(mw MiddlewareImplementation) gin.HandlerFunc {
 			c.JSON(errCode, reqErr.Error())
 		} else {
 			c.Next()
-			c.String(errCode, "")
 		}
 	}
 }


### PR DESCRIPTION
This fixes problems with wrong HTTP Status codes when we were proxying a request.
Example

`POST users/` Returns `200` instead of `201` even though the auth service was returning `201`
