### PR TITLE
Measure endpoint request time and store it in StatsD

### DIFF
--- a/api_manager.go
+++ b/api_manager.go
@@ -7,6 +7,7 @@ import (
 	"github.com/etcinit/speedbump"
 	"github.com/gin-gonic/gin"
 	"github.com/hellofresh/ginger-middleware/mongodb"
+	"gopkg.in/alexcesaro/statsd.v2"
 	"gopkg.in/redis.v3"
 )
 
@@ -18,8 +19,8 @@ type APIManager struct {
 }
 
 // NewAPIManager creates a new instance of the api manager
-func NewAPIManager(router *gin.Engine, redisClient *redis.Client, accessor *mongodb.DatabaseAccessor) *APIManager {
-	proxyRegister := &ProxyRegister{Engine: router}
+func NewAPIManager(router *gin.Engine, redisClient *redis.Client, accessor *mongodb.DatabaseAccessor, statsdClient *statsd.Client) *APIManager {
+	proxyRegister := &ProxyRegister{Engine: router, statsdClient: statsdClient}
 	return &APIManager{proxyRegister, redisClient, accessor}
 }
 

--- a/ci/assets/docker-compose.yml
+++ b/ci/assets/docker-compose.yml
@@ -10,6 +10,8 @@ services:
             PORT: '8080'
             DATABASE_DSN: 'mongodb://mongodb:27017/janus'
             REDIS_DSN: 'redis://redis:6379'
+            STATSD_DSN: 'statsd:8125'
+            STATSD_PREFIX: 'janus-docker.'
 
     mongodb:
         image: mongo
@@ -18,3 +20,11 @@ services:
 
     redis:
         image: redis
+
+    statsd:
+        image: hopsoft/graphite-statsd
+        ports:
+          - "8010:80"
+          - "2003:2003"
+          - "8125:8125/udp"
+          - "8126:8126"

--- a/config/specification.go
+++ b/config/specification.go
@@ -4,10 +4,12 @@ import "github.com/kelseyhightower/envconfig"
 
 // Specification for basic configurations
 type Specification struct {
-	DatabaseDSN string `envconfig:"DATABASE_DSN"`
-	Port        int    `envconfig:"PORT"`
-	Debug       bool   `envconfig:"DEBUG"`
-	StorageDSN  string `envconfig:"REDIS_DSN"`
+	DatabaseDSN  string `envconfig:"DATABASE_DSN"`
+	Port         int    `envconfig:"PORT"`
+	Debug        bool   `envconfig:"DEBUG"`
+	StatsdDSN    string `envconfig:"STATSD_DSN"`
+	StatsdPrefix string `envconfig:"STATSD_PREFIX"`
+	StorageDSN   string `envconfig:"REDIS_DSN"`
 }
 
 //LoadEnv loads environment variables

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: fdcc58eaba6c355535535fd7afc38cba0b69a3607f943c4e3dc5711ef21f30a6
-updated: 2016-11-18T14:32:26.654263265+01:00
+hash: 05df1d71d1d27d55bafc29d6f22238cfecf7141c90acea167996b8bafd2d87fa
+updated: 2016-11-18T16:37:29.842139654+01:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: 7664702784775e51966f0885f5cd27435916517b
@@ -43,6 +43,8 @@ imports:
   version: a408501be4d17ee978c04a618e7a1b22af058c0e
   subpackages:
   - unix
+- name: gopkg.in/alexcesaro/statsd.v2
+  version: 7fea3f0d2fab1ad973e641e51dba45443a311a90
 - name: gopkg.in/bsm/ratelimit.v1
   version: db14e161995a5177acef654cb0dd785e8ee8bc22
 - name: gopkg.in/go-playground/validator.v8
@@ -82,11 +84,12 @@ testImports:
   - reporters/stenographer
   - types
 - name: github.com/onsi/gomega
-  version: a78ae492d53aad5a7a232d0d0462c14c400e3ee7
+  version: d59fa0ac68bb5dd932ee8d24eed631cdd519efc3
   subpackages:
   - format
   - internal/assertion
   - internal/asyncassertion
+  - internal/oraclematcher
   - internal/testingtsupport
   - matchers
   - matchers/support/goraph/bipartitegraph

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/hellofresh/api-gateway
+package: github.com/hellofresh/janus
 license: MIT
 owners:
 - name: Italo Lelis de Vietro
@@ -22,6 +22,8 @@ import:
 - package: github.com/itsjamie/gin-cors
   version: ^1.0.0
 - package: github.com/hellofresh/ginger-middleware
+- package: gopkg.in/alexcesaro/statsd.v2
+  version: ~2.0.0
 testImport:
 - package: github.com/onsi/ginkgo
   version: ^1.2.0

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
+	"gopkg.in/alexcesaro/statsd.v2"
 )
 
 const (
@@ -14,8 +15,9 @@ const (
 
 // ProxyRegister represents a register proxy
 type ProxyRegister struct {
-	Engine  *gin.Engine
-	proxies []Proxy
+	Engine       *gin.Engine
+	proxies      []Proxy
+	statsdClient *statsd.Client
 }
 
 // RegisterMany registers many proxies at once
@@ -71,7 +73,7 @@ func (p *ProxyRegister) Exists(proxy Proxy) bool {
 // ToHandler turns a proxy configuration into a handler
 func (p *ProxyRegister) ToHandler(proxy Proxy) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		transport := &transport{http.DefaultTransport, c}
+		transport := &transport{http.DefaultTransport, c, p.statsdClient}
 		reverseProxy := NewSingleHostReverseProxy(proxy, transport)
 		reverseProxy.ServeHTTP(c.Writer, c.Request)
 	}


### PR DESCRIPTION
## What does this PR do?
I added support of StatsD, so now it's possible to measure the request time of proxied endpoints.
The StatsD is not mandatory and if its address is not provided, nothing will be changed in request flow.