### PR TITLE
Feature/append listen path

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -12,6 +12,7 @@ type Proxy struct {
 	ListenPath                  string   `bson:"listen_path" json:"listen_path" valid:"required"`
 	TargetURL                   string   `bson:"target_url" json:"target_url" valid:"url,required"`
 	StripListenPath             bool     `bson:"strip_listen_path" json:"strip_listen_path"`
+	AppendListenPath            bool     `bson:"append_listen_path" json:"append_listen_path"`
 	EnableLoadBalancing         bool     `bson:"enable_load_balancing" json:"enable_load_balancing"`
 	TargetList                  []string `bson:"target_list" json:"target_list"`
 	CheckHostAgainstUptimeTests bool     `bson:"check_host_against_uptime_tests" json:"check_host_against_uptime_tests"`


### PR DESCRIPTION
## What does this PR do?
Adds the append listen path logic to it. Now this is the behaviour:

`strip_listen_path`: true - Replaces the listen path in the target path if there is a match
`strip_listen_path`: false - Ignores the listen path and uses only the target path
`append_listen_path`: true - Appends the listen path on the target URL
