### PR TITLE
Replacing endless with grace

### DIFF
--- a/cmd/janus/main.go
+++ b/cmd/janus/main.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/fvbock/endless"
+	"github.com/facebookgo/grace/gracehttp"
 	"github.com/hellofresh/janus/api"
 	"github.com/hellofresh/janus/jwt"
 	"github.com/hellofresh/janus/loader"
@@ -97,5 +97,5 @@ func main() {
 	loadAPIEndpoints(router, authMiddleware, changeTracker)
 	loadOAuthEndpoints(router, authMiddleware, changeTracker)
 
-	log.Fatal(endless.ListenAndServe(fmt.Sprintf(":%v", globalConfig.Port), router))
+	log.Fatal(gracehttp.Serve(&http.Server{Addr: fmt.Sprintf(":%v", globalConfig.Port), Handler: router}))
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ed3ee0148038bf091c13ae9a8fa3dd77fb0c924e2edc19addbd01d069dbca33c
-updated: 2016-12-23T14:02:32.488938378+01:00
+hash: d020182e07c5e1ff860d20f9c4eaef0daafcd0364cb6f27a96578370891bf3bb
+updated: 2016-12-23T14:06:26.319366022+01:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: 7664702784775e51966f0885f5cd27435916517b
@@ -11,12 +11,17 @@ imports:
   version: e26f30cd88e1dd9707cb61d74fa5ee6b444fdb85
 - name: github.com/etcinit/speedbump
   version: 0dd4ce600c6cbf0f4d033846269f029dacf30cad
+- name: github.com/facebookgo/clock
+  version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
 - name: github.com/facebookgo/grace
   version: 5729e484473f52048578af1b80d0008c7024089b
   subpackages:
   - gracehttp
+  - gracenet
 - name: github.com/facebookgo/httpdown
   version: a3b1354551a26449fbe05f5d855937f6e7acbd71
+- name: github.com/facebookgo/stats
+  version: 1b76add642e42c6ffba7211ad7b3939ce654526e
 - name: github.com/justinas/alice
   version: 052b8b6c18edb9db317af86806d8e00ebaa94160
 - name: github.com/kelseyhightower/envconfig
@@ -27,14 +32,60 @@ imports:
   version: d9d9599b6aaf6a058cb7b1f48291ded2cbd13390
 - name: github.com/Sirupsen/logrus
   version: d26492970760ca5d33129d2d799e34be5c4782eb
+- name: golang.org/x/net
+  version: f315505cf3349909cdf013ea56690da34e96a451
+  subpackages:
+  - context
+- name: golang.org/x/sys
+  version: a408501be4d17ee978c04a618e7a1b22af058c0e
+  subpackages:
+  - unix
 - name: gopkg.in/alexcesaro/statsd.v2
   version: 7fea3f0d2fab1ad973e641e51dba45443a311a90
+- name: gopkg.in/bsm/ratelimit.v1
+  version: db14e161995a5177acef654cb0dd785e8ee8bc22
 - name: gopkg.in/mgo.v2
   version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
   subpackages:
   - bson
+  - internal/json
+  - internal/sasl
+  - internal/scram
 - name: gopkg.in/redis.v3
   version: b5e368500d0a508ef8f16e9c2d4025a8a46bcc29
+  subpackages:
+  - internal
+  - internal/consistenthash
+  - internal/hashtag
+  - internal/pool
 testImports:
 - name: github.com/onsi/ginkgo
-  version: ""
+  version: 462326b1628e124b23f42e87a8f2750e3c4e2d24
+  subpackages:
+  - config
+  - internal/codelocation
+  - internal/containernode
+  - internal/failer
+  - internal/leafnodes
+  - internal/remote
+  - internal/spec
+  - internal/specrunner
+  - internal/suite
+  - internal/testingtproxy
+  - internal/writer
+  - reporters
+  - reporters/stenographer
+  - types
+- name: github.com/onsi/gomega
+  version: a78ae492d53aad5a7a232d0d0462c14c400e3ee7
+  subpackages:
+  - format
+  - internal/assertion
+  - internal/asyncassertion
+  - internal/testingtsupport
+  - matchers
+  - matchers/support/goraph/bipartitegraph
+  - matchers/support/goraph/edge
+  - matchers/support/goraph/node
+  - matchers/support/goraph/util
+  - types

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 899a37b6e1f12f5f99b2f45947f47eef8b37ce9f37627fffe573f4300a0e7449
-updated: 2016-12-21T12:52:58.92199423+01:00
+hash: ed3ee0148038bf091c13ae9a8fa3dd77fb0c924e2edc19addbd01d069dbca33c
+updated: 2016-12-23T14:02:32.488938378+01:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: 7664702784775e51966f0885f5cd27435916517b
@@ -11,10 +11,12 @@ imports:
   version: e26f30cd88e1dd9707cb61d74fa5ee6b444fdb85
 - name: github.com/etcinit/speedbump
   version: 0dd4ce600c6cbf0f4d033846269f029dacf30cad
-- name: github.com/facebookgo/clock
-  version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
-- name: github.com/fvbock/endless
-  version: 67d0a784ad8ab10a69d12107f6de220db0c18002
+- name: github.com/facebookgo/grace
+  version: 5729e484473f52048578af1b80d0008c7024089b
+  subpackages:
+  - gracehttp
+- name: github.com/facebookgo/httpdown
+  version: a3b1354551a26449fbe05f5d855937f6e7acbd71
 - name: github.com/justinas/alice
   version: 052b8b6c18edb9db317af86806d8e00ebaa94160
 - name: github.com/kelseyhightower/envconfig
@@ -25,63 +27,14 @@ imports:
   version: d9d9599b6aaf6a058cb7b1f48291ded2cbd13390
 - name: github.com/Sirupsen/logrus
   version: d26492970760ca5d33129d2d799e34be5c4782eb
-- name: golang.org/x/net
-  version: f315505cf3349909cdf013ea56690da34e96a451
-  subpackages:
-  - context
-- name: golang.org/x/sys
-  version: a408501be4d17ee978c04a618e7a1b22af058c0e
-  subpackages:
-  - unix
 - name: gopkg.in/alexcesaro/statsd.v2
   version: 7fea3f0d2fab1ad973e641e51dba45443a311a90
-- name: gopkg.in/bsm/ratelimit.v1
-  version: db14e161995a5177acef654cb0dd785e8ee8bc22
 - name: gopkg.in/mgo.v2
   version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
   subpackages:
   - bson
-  - internal/json
-  - internal/sasl
-  - internal/scram
 - name: gopkg.in/redis.v3
   version: b5e368500d0a508ef8f16e9c2d4025a8a46bcc29
-  subpackages:
-  - internal
-  - internal/consistenthash
-  - internal/hashtag
-  - internal/pool
 testImports:
 - name: github.com/onsi/ginkgo
-  version: 462326b1628e124b23f42e87a8f2750e3c4e2d24
-  subpackages:
-  - config
-  - internal/codelocation
-  - internal/containernode
-  - internal/failer
-  - internal/leafnodes
-  - internal/remote
-  - internal/spec
-  - internal/specrunner
-  - internal/suite
-  - internal/testingtproxy
-  - internal/writer
-  - reporters
-  - reporters/stenographer
-  - types
-- name: github.com/onsi/gomega
-  version: d59fa0ac68bb5dd932ee8d24eed631cdd519efc3
-  subpackages:
-  - format
-  - internal/assertion
-  - internal/asyncassertion
-  - internal/oraclematcher
-  - internal/testingtsupport
-  - matchers
-  - matchers/support/goraph/bipartitegraph
-  - matchers/support/goraph/edge
-  - matchers/support/goraph/node
-  - matchers/support/goraph/util
-  - types
-- name: gopkg.in/yaml.v2
-  version: 31c299268d302dd0aa9a0dcf765a3d58971ac83f
+  version: ""

--- a/glide.yaml
+++ b/glide.yaml
@@ -30,7 +30,10 @@ import:
 - package: github.com/justinas/alice
   version: ^1.0.0
 - package: github.com/bshuster-repo/logrus-logstash-hook
-- package: github.com/fvbock/endless
+- package: github.com/facebookgo/grace
+  subpackages:
+  - gracehttp
+- package: github.com/facebookgo/httpdown
 testImport:
 - package: github.com/onsi/ginkgo
   version: ^1.2.0

--- a/glide.yaml
+++ b/glide.yaml
@@ -34,6 +34,7 @@ import:
   subpackages:
   - gracehttp
 - package: github.com/facebookgo/httpdown
+- package: github.com/facebookgo/clock
 testImport:
 - package: github.com/onsi/ginkgo
   version: ^1.2.0


### PR DESCRIPTION
## What does this PR do?
Since endless wasn't working really well with runit, we are replacing it with [grace](https://github.com/facebookgo/grace)
