### PR TITLE
Deny duplicates in proxy registration

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -85,7 +85,7 @@ func (u *Controller) PutBy() http.HandlerFunc {
 	}
 }
 
-// POST /apps
+// Post corresponds to POST /apis to create a new Proxy definition
 func (u *Controller) Post() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		repo := u.getRepository(u.getDatabase(r))
@@ -96,8 +96,17 @@ func (u *Controller) Post() http.HandlerFunc {
 			panic(errors.New(http.StatusInternalServerError, err.Error()))
 		}
 
+		def, err := repo.FindByListenPath(definition.Proxy.ListenPath)
+		if nil != err && err != mgo.ErrNotFound {
+			panic(errors.New(http.StatusBadRequest, err.Error()))
+		}
+
+		if def != nil {
+			panic(errors.ErrProxyExists)
+		}
 		err = repo.Add(definition)
 		if nil != err {
+
 			panic(errors.New(http.StatusBadRequest, err.Error()))
 		}
 

--- a/api/mongodb_repository.go
+++ b/api/mongodb_repository.go
@@ -55,6 +55,14 @@ func (r *MongoAPISpecRepository) FindByID(id string) (*Definition, error) {
 	return result, err
 }
 
+// FindByListenPath searches an existing Proxy definition by its listen_path
+func (r *MongoAPISpecRepository) FindByListenPath(path string) (*Definition, error) {
+	var result *Definition
+	err := r.coll.Find(bson.M{"proxy.listen_path": path}).One(&result)
+
+	return result, err
+}
+
 // Add adds a country to the repository
 func (r *MongoAPISpecRepository) Add(definition *Definition) error {
 	var id bson.ObjectId

--- a/errors/types.go
+++ b/errors/types.go
@@ -5,4 +5,6 @@ import "net/http"
 var (
 	// ErrInvalidID represents an invalid indentifier
 	ErrInvalidID = New(http.StatusBadRequest, "Please provide a valid ID")
+	// ErrProxyExists occurs when you try to register an already registered proxy
+	ErrProxyExists = New(http.StatusBadRequest, "Proxy already registered")
 )


### PR DESCRIPTION
## What does this PR do?
With this PR, the POST-handler for apis checks if the proxy you are about to register already exists in the database. It denies it if it does and prevents the database from faulty state.

