### PR TITLE
Change rate limit redis key prefix to use slug

### DIFF
--- a/pkg/api/loader.go
+++ b/pkg/api/loader.go
@@ -58,7 +58,7 @@ func (m *Loader) RegisterApi(referenceSpec *Spec) {
 				panic(err)
 			}
 
-			limiterStore, err := m.store.ToLimiterStore(referenceSpec.Name)
+			limiterStore, err := m.store.ToLimiterStore(referenceSpec.Slug)
 			if err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
Possible fix for rate limit bug assuming redis is having issues with keys containing spaces. Probably good practice even if this isn't the cause of the bug :)