### PR TITLE
Fixes problems with long expiration time

### DIFF
--- a/pkg/oauth/manager.go
+++ b/pkg/oauth/manager.go
@@ -2,7 +2,6 @@ package oauth
 
 import (
 	"encoding/json"
-	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/hellofresh/janus/pkg/session"
@@ -23,10 +22,10 @@ func (o *Manager) KeyExists(accessToken string) (bool, error) {
 // Set a new access token and its session to the storage
 func (o *Manager) Set(accessToken string, session session.SessionState, resetTTLTo int64) error {
 	value, _ := json.Marshal(session)
-	expireDuration := time.Duration(resetTTLTo) * time.Second
+	// expireDuration := time.Duration(resetTTLTo) * time.Second
 
 	log.Debugf("Storing key %s for %d seconds", accessToken, resetTTLTo)
-	go o.Storage.Set(accessToken, string(value), expireDuration)
+	go o.Storage.Set(accessToken, string(value), resetTTLTo)
 
 	return nil
 }

--- a/pkg/oauth/manager.go
+++ b/pkg/oauth/manager.go
@@ -21,8 +21,10 @@ func (o *Manager) KeyExists(accessToken string) (bool, error) {
 
 // Set a new access token and its session to the storage
 func (o *Manager) Set(accessToken string, session session.SessionState, resetTTLTo int64) error {
-	value, _ := json.Marshal(session)
-	// expireDuration := time.Duration(resetTTLTo) * time.Second
+	value, err := json.Marshal(session)
+	if err != nil {
+		return err
+	}
 
 	log.Debugf("Storing key %s for %d seconds", accessToken, resetTTLTo)
 	go o.Storage.Set(accessToken, string(value), resetTTLTo)

--- a/pkg/store/in_memory.go
+++ b/pkg/store/in_memory.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"sync"
-	"time"
 
 	"github.com/ulule/limiter"
 )
@@ -39,7 +38,7 @@ func (s *InMemoryStore) Get(key string) (string, error) {
 	return s.get(key)
 }
 
-func (s *InMemoryStore) Set(key string, value string, expire time.Duration) error {
+func (s *InMemoryStore) Set(key string, value string, expire int64) error {
 	s.Lock()
 	defer s.Unlock()
 
@@ -59,7 +58,7 @@ func (s *InMemoryStore) get(key string) (string, error) {
 	return s.data[key], nil
 }
 
-func (s *InMemoryStore) set(key string, value string, expire time.Duration) error {
+func (s *InMemoryStore) set(key string, value string, expire int64) error {
 	s.data[key] = value
 	return nil
 }

--- a/pkg/store/redis.go
+++ b/pkg/store/redis.go
@@ -1,8 +1,6 @@
 package store
 
 import (
-	"time"
-
 	"github.com/garyburd/redigo/redis"
 	"github.com/ulule/limiter"
 )
@@ -76,15 +74,15 @@ func (s *RedisStore) Get(key string) (string, error) {
 	return redis.String(conn.Do("GET", key))
 }
 
-func (s *RedisStore) Set(key string, value string, expire time.Duration) error {
+func (s *RedisStore) Set(key string, value string, expire int64) error {
 	conn := s.Pool.Get()
 	defer conn.Close()
 
 	var err error
-	if int(expire.Seconds()) == 0 {
+	if expire == 0 {
 		_, err = conn.Do("SET", key, value)
 	} else {
-		_, err = conn.Do("SETEX", key, expire.Seconds(), value)
+		_, err = conn.Do("SETEX", key, expire, value)
 	}
 	if err != nil {
 		return err

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -10,7 +10,7 @@ import (
 type Store interface {
 	Exists(key string) (bool, error)
 	Get(key string) (string, error)
-	Set(key string, value string, expire time.Duration) error
+	Set(key string, value string, expire int64) error
 	ToLimiterStore(prefix string) (limiter.Store, error)
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes problems dealing with long numbers being converted to seconds which makes them even bigger.
When working with, let's say a month of expiration time which is `2629743` seconds, go was converting this to the scientific notation `2.592e+6`, which is 2 seconds for redis.

This PR fixes this problem by only accepting integers as a value for expiration