### PR TITLE
Track muted stats in logs

### DIFF
--- a/cmd/janus/init.go
+++ b/cmd/janus/init.go
@@ -26,7 +26,7 @@ var (
 func init() {
 	globalConfig, err = config.LoadEnv()
 	if nil != err {
-		log.Panic(err.Error())
+		log.WithError(err).Panic("Failed to load config from environment")
 	}
 }
 
@@ -34,7 +34,7 @@ func init() {
 func init() {
 	level, err := log.ParseLevel(strings.ToLower(globalConfig.LogLevel))
 	if err != nil {
-		log.Error("Error getting level", err)
+		log.WithError(err).Error("Error getting level")
 	}
 
 	log.SetLevel(level)
@@ -48,7 +48,7 @@ func init() {
 func init() {
 	accessor, err = middleware.InitDB(globalConfig.Database.DSN)
 	if err != nil {
-		log.Fatalf("Couldn't connect to the mongodb database: %s", err.Error())
+		log.WithError(err).Fatal("Couldn't connect to the mongodb database")
 	}
 }
 
@@ -65,7 +65,7 @@ func init() {
 	log.Debugf("Trying to connect to redis pool: %s", dsn)
 	storage, err = store.NewRedisStore(pool)
 	if err != nil {
-		log.Fatalf("Couldn't connect to the redis pool: %s", err.Error())
+		log.WithError(err).Fatal("Couldn't connect to the redis pool")
 	}
 }
 
@@ -92,9 +92,9 @@ func init() {
 	if err != nil {
 		log.WithError(err).
 			WithFields(log.Fields{
-			"dsn":    statsdConfig.DSN,
-			"prefix": statsdConfig.Prefix,
-		}).Warning("An error occurred while connecting to StatsD. Client will be muted.")
+				"dsn":    statsdConfig.DSN,
+				"prefix": statsdConfig.Prefix,
+			}).Warning("An error occurred while connecting to StatsD. Client will be muted.")
 		muted = true
 	}
 

--- a/cmd/janus/main.go
+++ b/cmd/janus/main.go
@@ -65,7 +65,7 @@ func main() {
 	defer accessor.Close()
 	defer statsdClient.Close()
 
-	statsClient := stats.NewStatsClient(statsdClient)
+	statsClient := stats.NewStatsClient(statsdClient, globalConfig.Statsd.DSN == "")
 
 	// create router
 	r := router.NewHttpTreeMuxRouter()

--- a/cmd/janus/main.go
+++ b/cmd/janus/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hellofresh/janus/pkg/oauth"
 	"github.com/hellofresh/janus/pkg/proxy"
 	"github.com/hellofresh/janus/pkg/router"
-	"github.com/hellofresh/janus/pkg/stats"
 )
 
 //loadAPIEndpoints register api endpoints
@@ -63,9 +62,7 @@ func loadAuthEndpoints(router router.Router, authMiddleware *jwt.Middleware) {
 
 func main() {
 	defer accessor.Close()
-	defer statsdClient.Close()
-
-	statsClient := stats.NewStatsClient(statsdClient, globalConfig.Statsd.DSN == "")
+	defer statsClient.Close()
 
 	// create router
 	r := router.NewHttpTreeMuxRouter()

--- a/pkg/oauth/transport.go
+++ b/pkg/oauth/transport.go
@@ -27,7 +27,7 @@ func NewAwareTransport(manager *Manager, oAuthServersRepo *MongoRepository, stat
 	return &AwareTransport{manager, oAuthServersRepo, statsClient}
 }
 
-// GetRoundTripper returns initialized RoundTripper insnace
+// GetRoundTripper returns initialized RoundTripper instance
 func (at *AwareTransport) GetRoundTripper(roundTripper http.RoundTripper) http.RoundTripper {
 	return &RoundTripper{roundTripper, at.manager, at.oAuthServersRepo, at.statsClient}
 }

--- a/pkg/stats/incrementer.go
+++ b/pkg/stats/incrementer.go
@@ -1,17 +1,23 @@
 package stats
 
 import (
+	log "github.com/Sirupsen/logrus"
 	statsd "gopkg.in/alexcesaro/statsd.v2"
 )
 
 type Incrementer struct {
-	c *statsd.Client
+	c     *statsd.Client
+	muted bool
 }
 
-func NewIncrementer(c *statsd.Client) *Incrementer {
-	return &Incrementer{c}
+func NewIncrementer(c *statsd.Client, muted bool) *Incrementer {
+	return &Incrementer{c, muted}
 }
 
 func (t *Incrementer) Increment(bucket string) {
-	t.c.Increment(bucket)
+	if t.muted {
+		log.WithField("bucket", bucket).Debug("Muted stats counter increment")
+	} else {
+		t.c.Increment(bucket)
+	}
 }

--- a/pkg/stats/incrementer.go
+++ b/pkg/stats/incrementer.go
@@ -1,23 +1,17 @@
 package stats
 
 import (
-	log "github.com/Sirupsen/logrus"
 	statsd "gopkg.in/alexcesaro/statsd.v2"
 )
 
-type Incrementer struct {
-	c     *statsd.Client
-	muted bool
+type Incrementer interface {
+	Increment(bucket string)
 }
 
-func NewIncrementer(c *statsd.Client, muted bool) *Incrementer {
-	return &Incrementer{c, muted}
-}
-
-func (t *Incrementer) Increment(bucket string) {
-	if t.muted {
-		log.WithField("bucket", bucket).Debug("Muted stats counter increment")
+func NewIncrementer(c *statsd.Client, muted bool) Incrementer {
+	if muted {
+		return &MutedIncrementer{}
 	} else {
-		t.c.Increment(bucket)
+		return &LiveIncrementer{c}
 	}
 }

--- a/pkg/stats/live_incrementer.go
+++ b/pkg/stats/live_incrementer.go
@@ -1,0 +1,13 @@
+package stats
+
+import (
+	statsd "gopkg.in/alexcesaro/statsd.v2"
+)
+
+type LiveIncrementer struct {
+	c *statsd.Client
+}
+
+func (t *LiveIncrementer) Increment(bucket string) {
+	t.c.Increment(bucket)
+}

--- a/pkg/stats/live_time_tracker.go
+++ b/pkg/stats/live_time_tracker.go
@@ -1,0 +1,18 @@
+package stats
+
+import (
+	statsd "gopkg.in/alexcesaro/statsd.v2"
+)
+
+type LiveTimeTracker struct {
+	timer statsd.Timing
+	c     *statsd.Client
+}
+
+func (t *LiveTimeTracker) Start() {
+	t.timer = t.c.NewTiming()
+}
+
+func (t *LiveTimeTracker) Finish(bucket string) {
+	t.timer.Send(bucket)
+}

--- a/pkg/stats/muted_incrementer.go
+++ b/pkg/stats/muted_incrementer.go
@@ -1,0 +1,11 @@
+package stats
+
+import (
+	log "github.com/Sirupsen/logrus"
+)
+
+type MutedIncrementer struct{}
+
+func (t *MutedIncrementer) Increment(bucket string) {
+	log.WithField("bucket", bucket).Debug("Muted stats counter increment")
+}

--- a/pkg/stats/muted_time_tracker.go
+++ b/pkg/stats/muted_time_tracker.go
@@ -1,0 +1,25 @@
+package stats
+
+import (
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	statsd "gopkg.in/alexcesaro/statsd.v2"
+)
+
+type MutedTimeTracker struct {
+	timer statsd.Timing
+	c     *statsd.Client
+}
+
+func (t *MutedTimeTracker) Start() {
+	t.timer = t.c.NewTiming()
+}
+
+func (t *MutedTimeTracker) Finish(bucket string) {
+	log.WithFields(log.Fields{
+		"bucket":   bucket,
+		"elapsed":  int(t.timer.Duration() / time.Millisecond),
+		"sampling": "ms",
+	}).Debug("Muted stats timer send")
+}

--- a/pkg/stats/stats_client.go
+++ b/pkg/stats/stats_client.go
@@ -15,11 +15,11 @@ func NewStatsClient(client *statsd.Client, muted bool) *StatsClient {
 	return &StatsClient{client, muted}
 }
 
-func (f *StatsClient) BuildTimeTracker() *TimeTracker {
+func (f *StatsClient) BuildTimeTracker() TimeTracker {
 	return NewTimeTracker(f.client, f.muted)
 }
 
-func (f *StatsClient) TrackRequest(r *http.Request, tt *TimeTracker, success bool) {
+func (f *StatsClient) TrackRequest(r *http.Request, tt TimeTracker, success bool) {
 	b := RequestBucket(r)
 	i := NewIncrementer(f.client, f.muted)
 
@@ -31,7 +31,7 @@ func (f *StatsClient) TrackRequest(r *http.Request, tt *TimeTracker, success boo
 	i.Increment(RequestsWithSuffixBucket(r, success))
 }
 
-func (f *StatsClient) TrackRoundTrip(r *http.Request, tt *TimeTracker, success bool) {
+func (f *StatsClient) TrackRoundTrip(r *http.Request, tt TimeTracker, success bool) {
 	b := RoundTripBucket(r, success)
 	i := NewIncrementer(f.client, f.muted)
 

--- a/pkg/stats/stats_client.go
+++ b/pkg/stats/stats_client.go
@@ -8,19 +8,20 @@ import (
 
 type StatsClient struct {
 	client *statsd.Client
+	muted  bool
 }
 
-func NewStatsClient(client *statsd.Client) *StatsClient {
-	return &StatsClient{client}
+func NewStatsClient(client *statsd.Client, muted bool) *StatsClient {
+	return &StatsClient{client, muted}
 }
 
 func (f *StatsClient) BuildTimeTracker() *TimeTracker {
-	return NewTimeTracker(f.client)
+	return NewTimeTracker(f.client, f.muted)
 }
 
 func (f *StatsClient) TrackRequest(r *http.Request, tt *TimeTracker, success bool) {
 	b := RequestBucket(r)
-	i := NewIncrementer(f.client)
+	i := NewIncrementer(f.client, f.muted)
 
 	tt.Finish(b)
 	i.Increment(b)
@@ -32,7 +33,7 @@ func (f *StatsClient) TrackRequest(r *http.Request, tt *TimeTracker, success boo
 
 func (f *StatsClient) TrackRoundTrip(r *http.Request, tt *TimeTracker, success bool) {
 	b := RoundTripBucket(r, success)
-	i := NewIncrementer(f.client)
+	i := NewIncrementer(f.client, f.muted)
 
 	tt.Finish(b)
 	i.Increment(b)

--- a/pkg/stats/stats_client.go
+++ b/pkg/stats/stats_client.go
@@ -40,3 +40,7 @@ func (f *StatsClient) TrackRoundTrip(r *http.Request, tt TimeTracker, success bo
 	i.Increment(totalRoundTripBucket)
 	i.Increment(RoundTripSuffixBucket(success))
 }
+
+func (f *StatsClient) Close() {
+	f.client.Close()
+}

--- a/pkg/stats/time_tracker.go
+++ b/pkg/stats/time_tracker.go
@@ -1,34 +1,18 @@
 package stats
 
 import (
-	"time"
-
-	log "github.com/Sirupsen/logrus"
 	statsd "gopkg.in/alexcesaro/statsd.v2"
 )
 
-type TimeTracker struct {
-	timer statsd.Timing
-	c     *statsd.Client
-	muted bool
+type TimeTracker interface {
+	Start()
+	Finish(bucket string)
 }
 
-func NewTimeTracker(c *statsd.Client, muted bool) *TimeTracker {
-	return &TimeTracker{c: c, muted: muted}
-}
-
-func (t *TimeTracker) Start() {
-	t.timer = t.c.NewTiming()
-}
-
-func (t *TimeTracker) Finish(bucket string) {
-	if t.muted {
-		log.WithFields(log.Fields{
-			"bucket":   bucket,
-			"elapsed":  int(t.timer.Duration() / time.Millisecond),
-			"sampling": "ms",
-		}).Debug("Muted stats timer send")
+func NewTimeTracker(c *statsd.Client, muted bool) TimeTracker {
+	if muted {
+		return &MutedTimeTracker{c: c}
 	} else {
-		t.timer.Send(bucket)
+		return &LiveTimeTracker{c: c}
 	}
 }


### PR DESCRIPTION
After merging I suggest to disable stats collecting in teams staging and, maybe, on global staging as it takes to much space in graphite - today I removed `7.5GB` staging counters and `4.2GB` staging timers data from graphite as it run out of free space again.