### PR TITLE
Implement OpenTracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ integrating an API gateway is a faster, more secure route than writing your own 
 This API Gateway offers powerful, yet lightweight features that allows fine gained control over your API ecosystem.
 
 * No dependency hell, single binary made with go
+* [OpenTracing](http://opentracing.io/) support for Distributed tracing (Supports Google Cloud Platform, Zipkin and Appdash)
 * HTTP/2 support
 * REST API, full programatic access to the internals makes it easy to manage your API users, keys and API Configuration from within your systems
 * Rate Limiting, easily rate limit your API users, rate limiting is granular and can be applied on a per-key basis
@@ -73,8 +74,8 @@ Just go to the [releases](https://github.com/hellofresh/janus/releases) page and
 
 After you have *janus* up and running we need to setup our first proxy. You can choose between:
 
-* [File System](docs/file_system.md)
-* [MongoDB](docs/mongodb.md)
+* [File System](https://hellofresh.gitbooks.io/janus/quick_start/file_system.html)
+* [MongoDB](https://hellofresh.gitbooks.io/janus/quick_start/mongodb.html)
 
 ## Contributing
 
@@ -82,5 +83,6 @@ To start contributing, please check [CONTRIBUTING](CONTRIBUTING.md).
 
 ## Documentation
 
-* Janus Docs: https://godoc.org/github.com/hellofresh/janus
+* Janus Docs: https://hellofresh.gitbooks.io/janus
+* Janus Go Docs: https://godoc.org/github.com/hellofresh/janus
 * Go lang: https://golang.org/

--- a/cmd/janus/init.go
+++ b/cmd/janus/init.go
@@ -7,7 +7,9 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/bshuster-repo/logrus-logstash-hook"
 	"github.com/hellofresh/janus/pkg/config"
+	tracerfactory "github.com/hellofresh/janus/pkg/opentracing"
 	"github.com/hellofresh/janus/pkg/store"
+	opentracing "github.com/opentracing/opentracing-go"
 	statsd "gopkg.in/alexcesaro/statsd.v2"
 )
 
@@ -38,6 +40,17 @@ func init() {
 		Type:            "Janus",
 		TimestampFormat: time.RFC3339Nano,
 	})
+}
+
+// initializes the
+func init() {
+	log.Debug("initializing Open Tracing")
+	tracer, err := tracerfactory.Build(globalConfig.Tracing)
+	if err != nil {
+		log.WithError(err).Panic("Could not build a tracer for open tracing")
+	}
+
+	opentracing.InitGlobalTracer(tracer)
 }
 
 // initializes the storage and managers

--- a/cmd/janus/main.go
+++ b/cmd/janus/main.go
@@ -118,12 +118,12 @@ func main() {
 
 func listenAndServe(handler http.Handler) error {
 	address := fmt.Sprintf(":%v", globalConfig.Port)
-	log.Infof("Listening on %v", address)
+	log.WithField("address", address).Info("Listening on")
+	log.Info("Janus started")
 	if globalConfig.IsHTTPS() {
 		return http.ListenAndServeTLS(address, globalConfig.CertPathTLS, globalConfig.KeyPathTLS, handler)
 	}
 
 	log.Info("Certificate and certificate key were not found, defaulting to HTTP")
-	log.Info("Janus started")
 	return http.ListenAndServe(address, handler)
 }

--- a/cmd/janus/main.go
+++ b/cmd/janus/main.go
@@ -23,6 +23,7 @@ func main() {
 	var readOnlyAPI bool
 	var err error
 
+	log.Info("Janus starting...")
 	defer statsdClient.Close()
 
 	statsClient := stats.NewStatsClient(statsdClient)
@@ -91,6 +92,7 @@ func main() {
 		middleware.NewStats(statsClient).Handler,
 		middleware.NewLogger().Handler,
 		middleware.NewRecovery(web.RecoveryHandler).Handler,
+		middleware.NewOpenTracing().Handler,
 	)
 
 	// create proxy register
@@ -121,6 +123,7 @@ func listenAndServe(handler http.Handler) error {
 		return http.ListenAndServeTLS(address, globalConfig.CertPathTLS, globalConfig.KeyPathTLS, handler)
 	}
 
-	log.Infof("certPathTLS or keyPathTLS not found, defaulting to HTTP")
+	log.Info("Certificate and certificate key were not found, defaulting to HTTP")
+	log.Info("Janus started")
 	return http.ListenAndServe(address, handler)
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,16 @@
-hash: fbc4f6a5092bb85f113cac2ba8445d8da1f90e4773ca2de0a01bfb12df942220
-updated: 2017-03-19T21:30:07.845529166+01:00
+hash: dbbdc1cc6c7b6be2fb332b30d6904be2c07619ced24e2787a77ff73f69522473
+updated: 2017-03-19T22:07:29.006237414+01:00
 imports:
+- name: cloud.google.com/go
+  version: 49b49ef3c9d0c5fec4438c6dda687093f6c1f8d8
+  subpackages:
+  - compute/metadata
+  - internal
+- name: github.com/ant0ine/go-json-rest
+  version: ce4b71cdf7ba29ef443d704bd923f5bbf281ee30
+  subpackages:
+  - rest
+  - rest/trie
 - name: github.com/asaskevich/govalidator
   version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877
 - name: github.com/bshuster-repo/logrus-logstash-hook
@@ -12,7 +22,23 @@ imports:
 - name: github.com/garyburd/redigo
   version: 8873b2f1995f59d4bcdd2b0dc9858e2cb9bf0c13
   subpackages:
+  - internal
   - redis
+- name: github.com/gogo/protobuf
+  version: 100ba4e885062801d56799d78530b73b178a78f3
+  subpackages:
+  - io
+  - proto
+- name: github.com/golang/protobuf
+  version: c9c7427a2a70d2eb3bafa0ab2dc163e45f143317
+  subpackages:
+  - proto
+- name: github.com/googleapis/gax-go
+  version: 8c5154c0fe5bf18cf649634d4c6df50897a32751
+- name: github.com/gorilla/context
+  version: 1ea25387ff6f684839d82767c1733ff4d4d15d0a
+- name: github.com/gorilla/mux
+  version: 392c28fe23e1c45ddba891b0320b3b5df220beea
 - name: github.com/hellofresh/gcloud-opentracing
   version: 8c9c9c8a60b3d4b71ad91d6aa60cd24399f355a7
 - name: github.com/justinas/alice
@@ -21,10 +47,21 @@ imports:
   version: f611eb38b3875cc3bd991ca91c51d06446afa14c
 - name: github.com/NYTimes/gziphandler
   version: 3b0c4852c5b9710340f1ed7b1a529c46a3bc0fc1
+- name: github.com/opentracing/basictracer-go
+  version: 1b32af207119a14b1b231d451df3ed04a72efebf
+  subpackages:
+  - wire
 - name: github.com/opentracing/opentracing-go
   version: 6edb48674bd9467b8e91fda004f2bd7202d60ce4
+  subpackages:
+  - ext
+  - log
+- name: github.com/patrickmn/go-cache
+  version: 1881a9bccb818787f68c52bfba648c6cf34c34fa
 - name: github.com/rs/cors
   version: a62a804a8a009876ca59105f7899938a1349f4b3
+- name: github.com/rs/xhandler
+  version: d9d9599b6aaf6a058cb7b1f48291ded2cbd13390
 - name: github.com/Sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/ulule/limiter
@@ -32,15 +69,88 @@ imports:
 - name: golang.org/x/net
   version: a6577fac2d73be281a500b310739095313165611
   subpackages:
+  - context
+  - context/ctxhttp
   - http2
+  - http2/hpack
+  - idna
+  - internal/timeseries
+  - lex/httplex
+  - trace
+- name: golang.org/x/oauth2
+  version: 30fcca6531eb4bb278493c9fb299295b3b145934
+  subpackages:
+  - google
+  - internal
+  - jws
+  - jwt
+- name: golang.org/x/sys
+  version: a408501be4d17ee978c04a618e7a1b22af058c0e
+  subpackages:
+  - unix
+- name: google.golang.org/api
+  version: 650535c7d6201e8304c92f38c922a9a3a36c6877
+  subpackages:
+  - cloudtrace/v1
+  - gensupport
+  - googleapi
+  - googleapi/internal/uritemplates
+  - support/bundler
+- name: google.golang.org/appengine
+  version: b79c28f0197795b4050bfcd7c4c2209136c594b1
+  subpackages:
+  - internal
+  - internal/app_identity
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/modules
+  - internal/remote_api
+  - internal/urlfetch
+  - urlfetch
+- name: google.golang.org/grpc
+  version: 708a7f9f3283aa2d4f6132d287d78683babe55c8
+  subpackages:
+  - codes
+  - credentials
+  - grpclog
+  - internal
+  - metadata
+  - naming
+  - peer
+  - stats
+  - tap
+  - transport
 - name: gopkg.in/alexcesaro/statsd.v2
   version: 7fea3f0d2fab1ad973e641e51dba45443a311a90
 - name: gopkg.in/mgo.v2
   version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
   subpackages:
   - bson
+  - internal/json
+  - internal/sasl
+  - internal/scram
+- name: sourcegraph.com/sourcegraph/appdash
+  version: 0192d7f0689d8577da4d76d3ed947485f51e32e1
+  subpackages:
+  - httptrace
+  - internal/wire
+  - opentracing
+  - sqltrace
+  - traceapp
+  - traceapp/tmpl
+- name: sourcegraph.com/sourcegraph/appdash-data
+  version: 73f23eafcf67cad684fba328dd545a116ac273ff
 testImports:
+- name: github.com/davecgh/go-spew
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
 - name: github.com/stretchr/testify
-  version: ""
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert

--- a/glide.lock
+++ b/glide.lock
@@ -1,11 +1,6 @@
-hash: dc78b56933a6c3f5ca7a452d68a643664f7bf2f290c9f41be54902730ecd2ec7
-updated: 2017-02-01T22:22:32.384224423+01:00
+hash: fbc4f6a5092bb85f113cac2ba8445d8da1f90e4773ca2de0a01bfb12df942220
+updated: 2017-03-19T21:30:07.845529166+01:00
 imports:
-- name: github.com/ant0ine/go-json-rest
-  version: ce4b71cdf7ba29ef443d704bd923f5bbf281ee30
-  subpackages:
-  - rest
-  - rest/trie
 - name: github.com/asaskevich/govalidator
   version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877
 - name: github.com/bshuster-repo/logrus-logstash-hook
@@ -13,56 +8,39 @@ imports:
 - name: github.com/dgrijalva/jwt-go
   version: d2709f9f1f31ebcda9651b03077758c1f3a0018c
 - name: github.com/dimfeld/httptreemux
-  version: a12c89c2c0f23f880dfd74af4832a23bae6e837a
+  version: 86f7c217d9043ebc6adfd8e2ed04a0bb1e1db651
 - name: github.com/garyburd/redigo
   version: 8873b2f1995f59d4bcdd2b0dc9858e2cb9bf0c13
   subpackages:
-  - internal
   - redis
+- name: github.com/hellofresh/gcloud-opentracing
+  version: 8c9c9c8a60b3d4b71ad91d6aa60cd24399f355a7
 - name: github.com/justinas/alice
   version: 052b8b6c18edb9db317af86806d8e00ebaa94160
 - name: github.com/kelseyhightower/envconfig
   version: f611eb38b3875cc3bd991ca91c51d06446afa14c
 - name: github.com/NYTimes/gziphandler
-  version: 6710af535839f57c687b62c4c23d649f9545d885
-- name: github.com/patrickmn/go-cache
-  version: 1881a9bccb818787f68c52bfba648c6cf34c34fa
+  version: 3b0c4852c5b9710340f1ed7b1a529c46a3bc0fc1
+- name: github.com/opentracing/opentracing-go
+  version: 6edb48674bd9467b8e91fda004f2bd7202d60ce4
 - name: github.com/rs/cors
   version: a62a804a8a009876ca59105f7899938a1349f4b3
-- name: github.com/rs/xhandler
-  version: d9d9599b6aaf6a058cb7b1f48291ded2cbd13390
 - name: github.com/Sirupsen/logrus
-  version: d26492970760ca5d33129d2d799e34be5c4782eb
+  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/ulule/limiter
   version: c242da0b4c9524723c5a2dc8e7d49c228d1bb33c
 - name: golang.org/x/net
-  version: f315505cf3349909cdf013ea56690da34e96a451
+  version: a6577fac2d73be281a500b310739095313165611
   subpackages:
-  - context
   - http2
-- name: golang.org/x/sys
-  version: a408501be4d17ee978c04a618e7a1b22af058c0e
-  subpackages:
-  - unix
 - name: gopkg.in/alexcesaro/statsd.v2
   version: 7fea3f0d2fab1ad973e641e51dba45443a311a90
 - name: gopkg.in/mgo.v2
   version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
   subpackages:
   - bson
-  - internal/json
-  - internal/sasl
-  - internal/scram
 testImports:
-- name: github.com/davecgh/go-spew
-  version: 2df174808ee097f90d259e432cc04442cf60be21
-  subpackages:
-  - spew
-- name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
-  subpackages:
-  - difflib
 - name: github.com/stretchr/testify
-  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  version: ""
   subpackages:
   - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,14 +1,14 @@
 package: github.com/hellofresh/janus
 import:
 - package: github.com/Sirupsen/logrus
-  version: ^0.11.0
+  version: ^0.11.5
 - package: github.com/asaskevich/govalidator
   version: ^5.0.0
 - package: github.com/bshuster-repo/logrus-logstash-hook
 - package: github.com/dgrijalva/jwt-go
   version: ^3.0.0
 - package: github.com/dimfeld/httptreemux
-  version: ^3.7.0
+  version: ^3.8.0
 - package: github.com/garyburd/redigo
   version: ^1.0.0
   subpackages:
@@ -16,11 +16,13 @@ import:
 - package: github.com/justinas/alice
   version: ^1.0.0
 - package: github.com/kelseyhightower/envconfig
-  version: ^1.2.0
+  version: ^1.3.0
 - package: github.com/rs/cors
   version: ^1.0.0
 - package: github.com/ulule/limiter
+  version: master
 - package: golang.org/x/net
+  version: master
   subpackages:
   - http2
 - package: gopkg.in/alexcesaro/statsd.v2
@@ -29,6 +31,11 @@ import:
   subpackages:
   - bson
 - package: github.com/NYTimes/gziphandler
+  version: master
+- package: github.com/opentracing/opentracing-go
+  version: ^1.0.1
+- package: github.com/hellofresh/gcloud-opentracing
+  version: master
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.1.4

--- a/glide.yaml
+++ b/glide.yaml
@@ -36,6 +36,9 @@ import:
   version: ^1.0.1
 - package: github.com/hellofresh/gcloud-opentracing
   version: master
+- package: sourcegraph.com/sourcegraph/appdash
+- package: github.com/gorilla/mux
+  version: ^1.3.0
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.1.4

--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -24,9 +24,7 @@ func NewController(repo Repository) *Controller {
 func (c *Controller) Get() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		span := opentracing.FromContext(r.Context(), "datastore.FindAll")
-
 		data, err := c.repo.FindAll()
-
 		span.Finish()
 
 		if err != nil {

--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/hellofresh/janus/pkg/errors"
+	"github.com/hellofresh/janus/pkg/opentracing"
 	"github.com/hellofresh/janus/pkg/request"
 	"github.com/hellofresh/janus/pkg/response"
 	"github.com/hellofresh/janus/pkg/router"
@@ -22,7 +23,12 @@ func NewController(repo Repository) *Controller {
 
 func (c *Controller) Get() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		span := opentracing.FromContext(r.Context(), "datastore.FindAll")
+
 		data, err := c.repo.FindAll()
+
+		span.Finish()
+
 		if err != nil {
 			panic(err.Error())
 		}
@@ -34,8 +40,10 @@ func (c *Controller) Get() http.HandlerFunc {
 func (c *Controller) GetBy() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		name := router.FromContext(r.Context()).ByName("name")
-
+		span := opentracing.FromContext(r.Context(), "datastore.FindByName")
 		data, err := c.repo.FindByName(name)
+		span.Finish()
+
 		if data == nil {
 			panic(ErrAPIDefinitionNotFound)
 		}
@@ -53,7 +61,10 @@ func (c *Controller) PutBy() http.HandlerFunc {
 		var err error
 
 		name := router.FromContext(r.Context()).ByName("name")
+		span := opentracing.FromContext(r.Context(), "datastore.FindByName")
 		definition, err := c.repo.FindByName(name)
+		span.Finish()
+
 		if definition == nil {
 			panic(ErrAPIDefinitionNotFound)
 		}
@@ -67,7 +78,10 @@ func (c *Controller) PutBy() http.HandlerFunc {
 			panic(errors.New(http.StatusInternalServerError, err.Error()))
 		}
 
+		span = opentracing.FromContext(r.Context(), "datastore.Add")
 		err = c.repo.Add(definition)
+		span.Finish()
+
 		if nil != err {
 			panic(errors.New(http.StatusBadRequest, err.Error()))
 		}
@@ -85,7 +99,10 @@ func (c *Controller) Post() http.HandlerFunc {
 			panic(errors.New(http.StatusInternalServerError, err.Error()))
 		}
 
+		span := opentracing.FromContext(r.Context(), "datastore.FindByListenPath")
 		def, err := c.repo.FindByListenPath(definition.Proxy.ListenPath)
+		span.Finish()
+
 		if nil != err && err != mgo.ErrNotFound {
 			panic(errors.New(http.StatusBadRequest, err.Error()))
 		}
@@ -94,7 +111,10 @@ func (c *Controller) Post() http.HandlerFunc {
 			panic(errors.ErrProxyExists)
 		}
 
+		span = opentracing.FromContext(r.Context(), "datastore.Add")
 		err = c.repo.Add(definition)
+		span.Finish()
+
 		if nil != err {
 			panic(errors.New(http.StatusBadRequest, err.Error()))
 		}
@@ -108,7 +128,10 @@ func (c *Controller) DeleteBy() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		name := router.FromContext(r.Context()).ByName("name")
 
+		span := opentracing.FromContext(r.Context(), "datastore.Remove")
 		err := c.repo.Remove(name)
+		span.Finish()
+
 		if err != nil {
 			panic(errors.New(http.StatusInternalServerError, err.Error()))
 		}

--- a/pkg/config/specification.go
+++ b/pkg/config/specification.go
@@ -71,7 +71,7 @@ type GoogleCloudTracing struct {
 // AppdashTracing holds the Appdash tracing configuration
 type AppdashTracing struct {
 	DSN string `envconfig:"TRACING_APPDASH_DSN"`
-	URL string `envconfig:"TRACING_APPDASH_URL" default:"http://localhost:8700"`
+	URL string `envconfig:"TRACING_APPDASH_URL"`
 }
 
 // Tracing represents the distributed tracing configuration

--- a/pkg/config/specification.go
+++ b/pkg/config/specification.go
@@ -82,7 +82,7 @@ type Tracing struct {
 
 // IsGoogleCloudEnabled checks if google cloud is enabled
 func (t Tracing) IsGoogleCloudEnabled() bool {
-	return len(t.GoogleCloudTracing.Email) > 0 && len(t.GoogleCloudTracing.PrivateKey) > 0 && len(t.GoogleCloudTracing.PrivateKeyID) > 0
+	return len(t.GoogleCloudTracing.Email) > 0 && len(t.GoogleCloudTracing.PrivateKey) > 0 && len(t.GoogleCloudTracing.PrivateKeyID) > 0 && len(t.GoogleCloudTracing.ProjectID) > 0
 }
 
 // IsAppdashEnabled checks if appdash is enabled

--- a/pkg/config/specification.go
+++ b/pkg/config/specification.go
@@ -8,32 +8,22 @@ import (
 
 // Specification for basic configurations
 type Specification struct {
-	Port                int    `envconfig:"PORT" default:"8080"`
-	APIPort             int    `envconfig:"API_PORT" default:"8081"`
-	Debug               bool   `envconfig:"DEBUG" description:"Enable debug mode"`
-	LogLevel            string `envconfig:"LOG_LEVEL" default:"info" description:"Log level"`
-	GraceTimeOut        int64  `envconfig:"GRACE_TIMEOUT" description:"Duration to give active requests a chance to finish during hot-reload"`
-	MaxIdleConnsPerHost int    `envconfig:"MAX_IDLE_CONNS_PER_HOST" description:"If non-zero, controls the maximum idle (keep-alive) to keep per-host."`
-	InsecureSkipVerify  bool   `envconfig:"INSECURE_SKIP_VERIFY" description:"Disable SSL certificate verification"`
-	// The Storage DSN, this could be `memory` or `redis`
-	StorageDSN string `envconfig:"STORAGE_DSN" default:"memory://localhost"`
-
-	// Path of certificate when using TLS
-	CertPathTLS string `envconfig:"CERT_PATH"`
-
-	// Path of key when using TLS
-	KeyPathTLS string `envconfig:"KEY_PATH"`
-
-	// Flush interval for upgraded Proxy connections
-	BackendFlushInterval time.Duration `envconfig:"BACKEND_FLUSH_INTERVAL" default:"20ms"`
-
-	// Defines the time period of how often the idle connections maintained
-	// by the proxy are closed.
-	CloseIdleConnsPeriod time.Duration `envconfig:"CLOSE_IDLE_CONNS_PERIOD"`
-
-	Database    Database
-	Statsd      Statsd
-	Credentials Credentials
+	Port                 int           `envconfig:"PORT" default:"8080" description:"Default application port"`
+	APIPort              int           `envconfig:"API_PORT" default:"8081" description:"Admin API port"`
+	Debug                bool          `envconfig:"DEBUG" description:"Enable debug mode"`
+	LogLevel             string        `envconfig:"LOG_LEVEL" default:"info" description:"Log level"`
+	GraceTimeOut         int64         `envconfig:"GRACE_TIMEOUT" description:"Duration to give active requests a chance to finish during hot-reload"`
+	MaxIdleConnsPerHost  int           `envconfig:"MAX_IDLE_CONNS_PER_HOST" description:"If non-zero, controls the maximum idle (keep-alive) to keep per-host."`
+	InsecureSkipVerify   bool          `envconfig:"INSECURE_SKIP_VERIFY" description:"Disable SSL certificate verification"`
+	StorageDSN           string        `envconfig:"STORAGE_DSN" default:"memory://localhost" description:"The Storage DSN, this could be 'memory' or 'redis'"`
+	CertPathTLS          string        `envconfig:"CERT_PATH" description:"Path of certificate when using TLS"`
+	KeyPathTLS           string        `envconfig:"KEY_PATH" description:"Path of key when using TLS"`
+	BackendFlushInterval time.Duration `envconfig:"BACKEND_FLUSH_INTERVAL" default:"20ms" description:"Flush interval for upgraded Proxy connections"`
+	CloseIdleConnsPeriod time.Duration `envconfig:"CLOSE_IDLE_CONNS_PERIOD" description:"Defines the time period of how often the idle connections maintained by the proxy are closed."`
+	Database             Database
+	Statsd               Statsd
+	Credentials          Credentials
+	Tracing              Tracing
 }
 
 // IsHTTPS checks if you have https enabled
@@ -68,6 +58,36 @@ type Credentials struct {
 	Secret   string `envconfig:"SECRET" required:"true"`
 	Username string `envconfig:"ADMIN_USERNAME" default:"admin"`
 	Password string `envconfig:"ADMIN_PASSWORD" default:"admin"`
+}
+
+// GoogleCloudTracing holds the Google Application Default Credentials
+type GoogleCloudTracing struct {
+	ProjectID    string `envconfig:"TRACING_GC_PROJECT_ID"`
+	Email        string `envconfig:"TRACING_GC_EMAIL"`
+	PrivateKey   string `envconfig:"TRACING_GC_PRIVATE_KEY"`
+	PrivateKeyID string `envconfig:"TRACING_GC_PRIVATE_ID"`
+}
+
+// AppdashTracing holds the Appdash tracing configuration
+type AppdashTracing struct {
+	DSN string `envconfig:"TRACING_APPDASH_DSN"`
+	URL string `envconfig:"TRACING_APPDASH_URL" default:"http://localhost:8700"`
+}
+
+// Tracing represents the distributed tracing configuration
+type Tracing struct {
+	GoogleCloudTracing GoogleCloudTracing
+	AppdashTracing     AppdashTracing
+}
+
+// IsGoogleCloudEnabled checks if google cloud is enabled
+func (t Tracing) IsGoogleCloudEnabled() bool {
+	return len(t.GoogleCloudTracing.Email) > 0 && len(t.GoogleCloudTracing.PrivateKey) > 0 && len(t.GoogleCloudTracing.PrivateKeyID) > 0
+}
+
+// IsAppdashEnabled checks if appdash is enabled
+func (t Tracing) IsAppdashEnabled() bool {
+	return len(t.AppdashTracing.DSN) > 0
 }
 
 //LoadEnv loads environment variables

--- a/pkg/middleware/opentracing.go
+++ b/pkg/middleware/opentracing.go
@@ -1,10 +1,10 @@
 package middleware
 
 import (
-	"context"
 	"net/http"
 
 	log "github.com/Sirupsen/logrus"
+	base "github.com/hellofresh/janus/pkg/opentracing"
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
@@ -40,9 +40,6 @@ func (h *OpenTracing) Handler(handler http.Handler) http.Handler {
 		span.SetTag("peer.address", r.RemoteAddr)
 		span.SetTag("span.kind", "server")
 
-		ctx := context.WithValue(r.Context(), "trace.span", span)
-		r = r.WithContext(ctx)
-
 		err = span.Tracer().Inject(
 			span.Context(),
 			opentracing.HTTPHeaders,
@@ -51,6 +48,6 @@ func (h *OpenTracing) Handler(handler http.Handler) http.Handler {
 			log.WithError(err).Error("Could not inject span context into header")
 		}
 
-		handler.ServeHTTP(w, r)
+		handler.ServeHTTP(w, base.ToContext(r, span))
 	})
 }

--- a/pkg/middleware/opentracing.go
+++ b/pkg/middleware/opentracing.go
@@ -1,0 +1,56 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	log "github.com/Sirupsen/logrus"
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+// OpenTracing is a middleware that traces the request latency
+type OpenTracing struct{}
+
+// NewOpenTracing creates a new instance of OpenTracing
+func NewOpenTracing() *OpenTracing {
+	return &OpenTracing{}
+}
+
+// Handler is the middleware function for OpenTracing
+func (h *OpenTracing) Handler(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var span opentracing.Span
+		var err error
+
+		// Attempt to join a trace by getting trace context from the headers.
+		wireContext, err := opentracing.GlobalTracer().Extract(
+			opentracing.HTTPHeaders,
+			opentracing.HTTPHeadersCarrier(r.Header))
+		if err != nil {
+			// If for whatever reason we can't join, go ahead an start a new root span.
+			span = opentracing.StartSpan(r.RequestURI)
+		} else {
+			span = opentracing.StartSpan(r.RequestURI, opentracing.ChildOf(wireContext))
+		}
+		defer span.Finish()
+
+		span.SetTag("component", "janus")
+		span.SetTag("http.method", r.Method)
+		span.SetTag("http.url", r.RequestURI)
+		span.SetTag("peer.address", r.RemoteAddr)
+		span.SetTag("span.kind", "server")
+
+		ctx := context.WithValue(r.Context(), "trace.span", span)
+		r = r.WithContext(ctx)
+
+		err = span.Tracer().Inject(
+			span.Context(),
+			opentracing.HTTPHeaders,
+			opentracing.HTTPHeadersCarrier(r.Header))
+		if err != nil {
+			log.WithError(err).Error("Could not inject span context into header")
+		}
+
+		handler.ServeHTTP(w, r)
+	})
+}

--- a/pkg/opentracing/appdash/server.go
+++ b/pkg/opentracing/appdash/server.go
@@ -17,21 +17,16 @@ import (
 // Server represents a new appdash server (local or remote)
 type Server struct {
 	collectorDSN    string
-	AppdashHTTPAddr string
+	appdashHTTPAddr string
 }
 
 // NewServer creates a new instance of Server
 func NewServer(collectorDSN string, appdashHTTPAddr string) *Server {
-	return &Server{collectorDSN: collectorDSN, AppdashHTTPAddr: appdashHTTPAddr}
+	return &Server{collectorDSN: collectorDSN, appdashHTTPAddr: appdashHTTPAddr}
 }
 
 // Listen starts the appdash server collector and UI
 func (s *Server) Listen() error {
-	if s.AppdashHTTPAddr == "" {
-		log.Info("Appdash is on remote mode")
-		return nil
-	}
-
 	memStore := appdash.NewMemoryStore()
 	store := &appdash.RecentStore{
 		MinEvictAge: 20 * time.Second,
@@ -39,7 +34,7 @@ func (s *Server) Listen() error {
 	}
 
 	s.listenCollector(s.collectorDSN, store)
-	s.listenWebUI(s.collectorDSN, store, memStore)
+	s.listenWebUI(s.appdashHTTPAddr, store, memStore)
 
 	return nil
 }

--- a/pkg/opentracing/appdash/server.go
+++ b/pkg/opentracing/appdash/server.go
@@ -1,0 +1,91 @@
+package appdash
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	opentracing "github.com/opentracing/opentracing-go"
+
+	log "github.com/Sirupsen/logrus"
+	"sourcegraph.com/sourcegraph/appdash"
+	appdashtracer "sourcegraph.com/sourcegraph/appdash/opentracing"
+	"sourcegraph.com/sourcegraph/appdash/traceapp"
+)
+
+// Server represents a new appdash server (local or remote)
+type Server struct {
+	collectorDSN    string
+	AppdashHTTPAddr string
+}
+
+// NewServer creates a new instance of Server
+func NewServer(collectorDSN string, appdashHTTPAddr string) *Server {
+	return &Server{collectorDSN: collectorDSN, AppdashHTTPAddr: appdashHTTPAddr}
+}
+
+// Listen starts the appdash server collector and UI
+func (s *Server) Listen() error {
+	if s.AppdashHTTPAddr == "" {
+		log.Info("Appdash is on remote mode")
+		return nil
+	}
+
+	memStore := appdash.NewMemoryStore()
+	store := &appdash.RecentStore{
+		MinEvictAge: 20 * time.Second,
+		DeleteStore: memStore,
+	}
+
+	s.listenCollector(s.collectorDSN, store)
+	s.listenWebUI(s.collectorDSN, store, memStore)
+
+	return nil
+}
+
+// GetTracer returns an open tracing compatible tracer
+func (s *Server) GetTracer() opentracing.Tracer {
+	collector := appdash.NewRemoteCollector(s.collectorDSN)
+
+	// Here we use the local collector to create a new opentracing.Tracer
+	return appdashtracer.NewTracer(collector)
+}
+
+func (s *Server) listenCollector(collectorDSN string, store appdash.Store) error {
+	l, err := net.Listen("tcp", collectorDSN)
+	if err != nil {
+		return err
+	}
+
+	collectorPort := l.Addr().(*net.TCPAddr).Port
+	log.Info("Appdash collector listening on tcp:%d", collectorPort)
+	cs := appdash.NewServer(l, appdash.NewLocalCollector(store))
+	go cs.Start()
+
+	return nil
+}
+
+func (s *Server) listenWebUI(appdashHTTPAddr string, store appdash.Store, queryer appdash.Queryer) error {
+	appdashURLStr := "http://localhost" + appdashHTTPAddr
+	appdashURL, err := url.Parse(appdashURLStr)
+	if err != nil {
+		return err
+	}
+
+	tapp, err := traceapp.New(nil, appdashURL)
+	if err != nil {
+		return err
+	}
+
+	tapp.Store = store
+	tapp.Queryer = queryer
+
+	log.Infof("Appdash web UI running at %s", appdashHTTPAddr)
+
+	go func() {
+		log.Fatal(http.ListenAndServe(appdashHTTPAddr, tapp))
+	}()
+
+	return nil
+}

--- a/pkg/opentracing/opentracing.go
+++ b/pkg/opentracing/opentracing.go
@@ -3,10 +3,18 @@ package opentracing
 import (
 	"context"
 
+	"net/http"
+
 	log "github.com/Sirupsen/logrus"
 	gcloudtracer "github.com/hellofresh/gcloud-opentracing"
 	"github.com/hellofresh/janus/pkg/config"
+	"github.com/hellofresh/janus/pkg/opentracing/appdash"
 	opentracing "github.com/opentracing/opentracing-go"
+)
+
+const (
+	// CtxSpanID is used to store the SpanID in a request's context
+	CtxSpanID = 0
 )
 
 // Build a tracer based on the configuration provided
@@ -15,7 +23,7 @@ func Build(config config.Tracing) (opentracing.Tracer, error) {
 		tracer, err := gcloudtracer.NewTracer(
 			context.Background(),
 			gcloudtracer.WithLogger(log.StandardLogger()),
-			gcloudtracer.WithProject(config.ProjectID),
+			gcloudtracer.WithProject(config.GoogleCloudTracing.ProjectID),
 			gcloudtracer.WithJWTCredentials(gcloudtracer.JWTCredentials{
 				Email:        config.GoogleCloudTracing.Email,
 				PrivateKey:   []byte(config.GoogleCloudTracing.PrivateKey),
@@ -27,7 +35,24 @@ func Build(config config.Tracing) (opentracing.Tracer, error) {
 		}
 
 		return tracer, nil
+	} else if config.IsAppdashEnabled() {
+		server, err := appdash.NewServer(config.AppdashTracing.DSN, config.AppdashTracing.URL)
+		if err != nil {
+			return nil, err
+		}
+
+		server.Listen()
+		return server.GetTracer(), nil
 	}
 
 	return nil, nil
+}
+
+func FromContext(ctx context.Context, name string) opentracing.Span {
+	parentSpan := ctx.Value(CtxSpanID).(opentracing.Span)
+	return opentracing.StartSpan(name, opentracing.ChildOf(parentSpan.Context()))
+}
+
+func ToContext(r *http.Request, span opentracing.Span) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), CtxSpanID, span))
 }

--- a/pkg/opentracing/opentracing.go
+++ b/pkg/opentracing/opentracing.go
@@ -36,23 +36,24 @@ func Build(config config.Tracing) (opentracing.Tracer, error) {
 
 		return tracer, nil
 	} else if config.IsAppdashEnabled() {
-		server, err := appdash.NewServer(config.AppdashTracing.DSN, config.AppdashTracing.URL)
+		server := appdash.NewServer(config.AppdashTracing.DSN, config.AppdashTracing.URL)
+		err := server.Listen()
 		if err != nil {
 			return nil, err
 		}
-
-		server.Listen()
 		return server.GetTracer(), nil
 	}
 
 	return nil, nil
 }
 
+// FromContext creates a span from a context that contains a parent span
 func FromContext(ctx context.Context, name string) opentracing.Span {
 	parentSpan := ctx.Value(CtxSpanID).(opentracing.Span)
 	return opentracing.StartSpan(name, opentracing.ChildOf(parentSpan.Context()))
 }
 
+// ToContext sets a span to a context
 func ToContext(r *http.Request, span opentracing.Span) *http.Request {
 	return r.WithContext(context.WithValue(r.Context(), CtxSpanID, span))
 }

--- a/pkg/opentracing/opentracing.go
+++ b/pkg/opentracing/opentracing.go
@@ -1,0 +1,33 @@
+package opentracing
+
+import (
+	"context"
+
+	log "github.com/Sirupsen/logrus"
+	gcloudtracer "github.com/hellofresh/gcloud-opentracing"
+	"github.com/hellofresh/janus/pkg/config"
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+// Build a tracer based on the configuration provided
+func Build(config config.Tracing) (opentracing.Tracer, error) {
+	if config.IsGoogleCloudEnabled() {
+		tracer, err := gcloudtracer.NewTracer(
+			context.Background(),
+			gcloudtracer.WithLogger(log.StandardLogger()),
+			gcloudtracer.WithProject(config.ProjectID),
+			gcloudtracer.WithJWTCredentials(gcloudtracer.JWTCredentials{
+				Email:        config.GoogleCloudTracing.Email,
+				PrivateKey:   []byte(config.GoogleCloudTracing.PrivateKey),
+				PrivateKeyID: config.GoogleCloudTracing.PrivateKeyID,
+			}),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return tracer, nil
+	}
+
+	return nil, nil
+}

--- a/pkg/opentracing/opentracing.go
+++ b/pkg/opentracing/opentracing.go
@@ -56,9 +56,10 @@ func Build(config config.Tracing) (opentracing.Tracer, error) {
 		}
 
 		return server.GetTracer(), nil
+	} else {
+		log.Debug("Not using a tracer as tracing system")
+		return &opentracing.NoopTracer{}, nil
 	}
-
-	return nil, nil
 }
 
 // FromContext creates a span from a context that contains a parent span

--- a/pkg/web/provider.go
+++ b/pkg/web/provider.go
@@ -60,13 +60,13 @@ func (p *Provider) Provide() error {
 
 func (p *Provider) listenAndServe(handler http.Handler) error {
 	address := fmt.Sprintf(":%v", p.Port)
-	log.Infof("Listening on %v", address)
+	log.WithField("address", address).Info("Listening on")
+	log.Info("Janus Admin API started")
 	if len(p.CertFile) > 0 && len(p.KeyFile) > 0 {
 		return http.ListenAndServeTLS(address, p.CertFile, p.KeyFile, handler)
 	}
 
 	log.Info("Certificate and certificate key were not found, defaulting to HTTP")
-	log.Info("Janus Admin API started")
 	return http.ListenAndServe(address, handler)
 }
 

--- a/pkg/web/provider.go
+++ b/pkg/web/provider.go
@@ -35,6 +35,7 @@ func (p *Provider) Provide() error {
 		middleware.NewLogger().Handler,
 		middleware.NewRecovery(RecoveryHandler).Handler,
 		gziphandler.GzipHandler,
+		middleware.NewOpenTracing().Handler,
 	)
 
 	// create endpoints
@@ -64,7 +65,8 @@ func (p *Provider) listenAndServe(handler http.Handler) error {
 		return http.ListenAndServeTLS(address, p.CertFile, p.KeyFile, handler)
 	}
 
-	log.Infof("certPathTLS or keyPathTLS not found, defaulting to HTTP")
+	log.Info("Certificate and certificate key were not found, defaulting to HTTP")
+	log.Info("Janus Admin API started")
 	return http.ListenAndServe(address, handler)
 }
 


### PR DESCRIPTION
## What does this PR do?

Implements [opentracing](http://opentracing.io/) for janus. You can choose between 2 tracers:

* Google Cloud Platform - [Stackdrive trace](https://cloud.google.com/trace/)
* [Appdash](https://github.com/sourcegraph/appdash) - Local or Remote

If you choose appdash as your tracer you can choose to run it using a shared instance (remote), in this case, you need to have an appdash server somewhere and point Janus to it. 
You can also use the default implementation that Janus provide with a built in appdash server.

I also added some basic tracing for the api and auth endpoints