### PR TITLE
Remove glide cache from image to dramatically reduce docker image size

### DIFF
--- a/ci/assets/Dockerfile
+++ b/ci/assets/Dockerfile
@@ -22,7 +22,8 @@ RUN set -ex \
     && apk del .build-deps \
     && rm -rf /var/cache/apk/* \
     && rm -rf /go/src/* \
-    && rm -rf /go/pkg/*
+    && rm -rf /go/pkg/* \
+    && rm -rf /root/.glide
 
 EXPOSE 8080
 EXPOSE 8081


### PR DESCRIPTION
I found that docker image dramatically increased after tracing feature merge. Investigation shown that glide cache has significant size and after application build we do not need it at all.

```
$ docker run janus:dev du -hs /root/.glide
246.4M	/root/.glide
```