### PR TITLE
Added stats second level ID autodiscovery, error logs monitoring

### DIFF
--- a/build/test.sh
+++ b/build/test.sh
@@ -27,11 +27,11 @@ FAIL="${ERROR_COLOR}FAIL ${NO_COLOR}"
 TARGETS=$@
 
 if [ "$RUN_INTEGRATION" ]; then
-echo "${OK_COLOR}Running unit and integration tests: ${NO_COLOR}"
-go test -v -race -cpu=1,2,4 -tags=integration ${TARGETS}
+    echo "${OK_COLOR}Running unit and integration tests: ${NO_COLOR}"
+    go test -race -cover -cpu=1,2,4 -tags=integration ${TARGETS}
 else
-echo "${OK_COLOR}Running unit tests: ${NO_COLOR}"
-go test -v -race -cpu=1,2,4 ${TARGETS}
+    echo "${OK_COLOR}Running unit tests: ${NO_COLOR}"
+    go test -race -cover -cpu=1,2,4 ${TARGETS}
 fi
 
 echo "${OK_COLOR}Formatting: ${NO_COLOR}"

--- a/cmd/janus/init.go
+++ b/cmd/janus/init.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hellofresh/janus/pkg/store"
 	"github.com/hellofresh/stats-go"
 	"github.com/hellofresh/stats-go/bucket"
+	"github.com/hellofresh/stats-go/hooks"
 	"github.com/opentracing/opentracing-go"
 	log "github.com/sirupsen/logrus"
 )
@@ -60,7 +61,13 @@ func init() {
 		log.WithError(err).Panic("Error initializing statsd client")
 	}
 
-	statsClient.SetHTTPMetricCallback(bucket.NewHasIDAtSecondLevelCallback(sectionsTestsMap))
+	statsClient.SetHTTPMetricCallback(bucket.NewHasIDAtSecondLevelCallback(&bucket.SecondLevelIDConfig{
+		HasIDAtSecondLevel:    sectionsTestsMap,
+		AutoDiscoverThreshold: globalConfig.Stats.AutoDiscoverThreshold,
+		AutoDiscoverWhiteList: globalConfig.Stats.AutoDiscoverWhiteList,
+	}))
+
+	log.AddHook(hooks.NewLogrusHook(statsClient, globalConfig.Stats.ErrorsSection))
 }
 
 // initializes the storage and managers

--- a/docs/misc/monitoring.md
+++ b/docs/misc/monitoring.md
@@ -3,7 +3,10 @@
 `Janus` monitoring is built on top of [`hellofresh/stats-go`](https://github.com/hellofresh/stats-go) library.
 You can configure it with the following env variables:
 
-* `STATS_DSN` - DSN of stats backend. `janus` uses `statsd` backend with fallback to debug log if DSN is not provided,
+* `STATS_DSN` (default `log://`) - DSN of stats backend. `janus` uses `statsd` backend with fallback to debug log if DSN is not provided,
   empty string or application fails to connect to `statsd` server on application start.
 * `STATS_PREFIX` - prefix for `statsd` metrics, e.g. `janus.dev.`, `janus.staging.`, `janus.live.`.
 * `STATS_IDS` - second level ID list for URLs to generalise metric names, see details in [Generalise resources by type and stripping resource ID](https://github.com/hellofresh/stats-go#generalise-resources-by-type-and-stripping-resource-id)
+* `STATS_AUTO_DISCOVER_THRESHOLD` - threshold for second level IDs autodiscovery, see details in [Generalise resources by type and stripping resource ID](https://github.com/hellofresh/stats-go#generalise-resources-by-type-and-stripping-resource-id)
+* `STATS_AUTO_DISCOVER_WHITE_LIST` - white list for second level IDs autodiscovery, see details in [Generalise resources by type and stripping resource ID](https://github.com/hellofresh/stats-go#generalise-resources-by-type-and-stripping-resource-id)
+* `STATS_ERRORS_SECTION` (default `error-log`) - section for error logs monitoring, see details in [Usage for error logs monitoring](https://github.com/hellofresh/stats-go#usage-for-error-logs-monitoring)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 3d3c01afd74d79db9dd2d59a274d1571958dd6e36775783b78228934c20eb919
-updated: 2017-07-05T11:03:10.184080762+02:00
+updated: 2017-07-13T11:04:22.294963499+02:00
 imports:
 - name: cloud.google.com/go
   version: 558b56dfa3c56acc26fef35cb07f97df0bb18b39
@@ -33,7 +33,7 @@ imports:
   - internal
   - redis
 - name: github.com/go-chi/chi
-  version: 967844826e58cf31213a7dfb82455d242ad85101
+  version: 08660a0ad10a8fa7beab3ad43afe66373d49d06a
   subpackages:
   - middleware
 - name: github.com/gogo/protobuf
@@ -67,7 +67,7 @@ imports:
 - name: github.com/hellofresh/logging-go
   version: e0dad001fe00320c380f9338e746beb0f832dca8
 - name: github.com/hellofresh/stats-go
-  version: aeae428c686577aea5e7bbcab1bcab51b4fb3b78
+  version: 83a84ddeb556c898599e404ec82b01f995599927
   subpackages:
   - bucket
   - incrementer
@@ -99,7 +99,7 @@ imports:
 - name: github.com/rs/cors
   version: 8dd4211afb5d08dbb39a533b9bb9e4b486351df6
 - name: github.com/sirupsen/logrus
-  version: 202f25545ea4cf9b191ff7f846df5d87c9382c2b
+  version: 7f976d3a76720c4c27af2ba716b85d2e0a7e38b1
   subpackages:
   - hooks/syslog
 - name: github.com/spf13/afero
@@ -123,7 +123,7 @@ imports:
 - name: github.com/ulule/limiter
   version: c242da0b4c9524723c5a2dc8e7d49c228d1bb33c
 - name: golang.org/x/net
-  version: 570fa1c91359c1869590e9cedf3b53162a51a167
+  version: 054b33e6527139ad5b1ec2f6232c3b175bd9a30c
   subpackages:
   - context
   - context/ctxhttp
@@ -207,3 +207,4 @@ testImports:
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
+  - require

--- a/pkg/config/specification.go
+++ b/pkg/config/specification.go
@@ -60,9 +60,12 @@ type Database struct {
 
 // Stats holds the configuration for stats
 type Stats struct {
-	DSN    string `envconfig:"STATS_DSN"`
-	Prefix string `envconfig:"STATS_PREFIX"`
-	IDs    string `envconfig:"STATS_IDS"`
+	DSN                   string   `envconfig:"STATS_DSN"`
+	Prefix                string   `envconfig:"STATS_PREFIX"`
+	IDs                   string   `envconfig:"STATS_IDS"`
+	AutoDiscoverThreshold uint     `envconfig:"STATS_AUTO_DISCOVER_THRESHOLD"`
+	AutoDiscoverWhiteList []string `envconfig:"STATS_AUTO_DISCOVER_WHITE_LIST"`
+	ErrorsSection         string   `envconfig:"STATS_ERRORS_SECTION"`
 }
 
 // Credentials represents the credentials that are going to be
@@ -115,6 +118,8 @@ func init() {
 	viper.SetDefault("web.tls.redisrect", true)
 	viper.SetDefault("web.credentials.username", "admin")
 	viper.SetDefault("web.credentials.password", "admin")
+	viper.SetDefault("stats.dsn", "log://")
+	viper.SetDefault("stats.errorsSection", "error-log")
 
 	logging.InitDefaults(viper.GetViper(), "log")
 }

--- a/pkg/config/specification_test.go
+++ b/pkg/config/specification_test.go
@@ -10,10 +10,17 @@ import (
 
 func Test_LoadEnv(t *testing.T) {
 	os.Setenv("PORT", "8001")
+	os.Setenv("STATS_AUTO_DISCOVER_WHITE_LIST", "api,foo,bar")
 
 	globalConfig, err := LoadEnv()
 	require.NoError(t, err)
 
 	assert.Equal(t, 8001, globalConfig.Port)
 	assert.Equal(t, 8081, globalConfig.Web.Port)
+	assert.Equal(t, uint(0), globalConfig.Stats.AutoDiscoverThreshold)
+	assert.Equal(t, []string{"api", "foo", "bar"}, globalConfig.Stats.AutoDiscoverWhiteList)
+	assert.Equal(t, "error-log", globalConfig.Stats.ErrorsSection)
+	assert.False(t, globalConfig.TLS.IsHTTPS())
+	assert.False(t, globalConfig.Tracing.IsGoogleCloudEnabled())
+	assert.False(t, globalConfig.Tracing.IsAppdashEnabled())
 }


### PR DESCRIPTION
* Bumped `stats-go` to `v0.4.0`
* Added support for stats second level ID autodiscovery
* Added error logs monitoring