### PR TITLE
Fix wrong documentation link references

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -73,8 +73,8 @@ Just go to the [releases](https://github.com/hellofresh/janus/releases) page and
 
 After you have *janus* up and running we need to setup our first proxy. You can choose between:
 
-* [File System](docs/quick_start/file_system.md)
-* [MongoDB](docs/quick_start/mongodb.md)
+* [File System](quick_start/file_system.md)
+* MongoDB
 
 ## Contributing
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -8,6 +8,7 @@
     * [Add an endpoint](quick_start/add_endpoint.md)
     * [Add Plugins](quick_start/add_plugins.md)
     * [Authentication](quick_start/add_auth.md)
+    * [Adding your API - File System](quick_start/file_system.md)
 * [Proxy Reference](proxy/README.md)
     * [Terminology](proxy/terminology.md)
     * [Overview](proxy/overview.md)


### PR DESCRIPTION
Some links were not pointing to subpages with the proper path relative root documentation

## What does this PR do?
It adds the link to file system proxy. Since i could not find any documentation file for the MongoDB one, i decided to remove the link while keeping the name in the list of options available.
