### PR TITLE
Validate the Upstream URL on the Admin API

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -19,7 +19,7 @@ func TestSuccessfulValidation(t *testing.T) {
 	instance := api.NewDefinition()
 	instance.Name = "Test"
 	instance.Proxy.ListenPath = "/"
-	instance.Proxy.UpstreamURL = "http://example.com"
+	instance.Proxy.UpstreamURL = ""
 
 	isValid, err := instance.Validate()
 	require.NoError(t, err)

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -18,4 +18,7 @@ var (
 
 	// ErrDBContextNotSet is used when the database request context is not set
 	ErrDBContextNotSet = errors.New(http.StatusInternalServerError, "DB context was not set for this request")
+
+	// ErrUpstreamURLdeprecated is used when the proxy API definition upstream_url is set
+	ErrUpstreamURLdeprecated = errors.New(http.StatusBadRequest, "upstream_url is deprecated. please use upstreams instead")
 )

--- a/pkg/api/file_repository_test.go
+++ b/pkg/api/file_repository_test.go
@@ -47,7 +47,7 @@ func TestNewFileSystemRepository(t *testing.T) {
 		Name: "foo-bar",
 		Proxy: &proxy.Definition{
 			ListenPath:  "/foo/bar/*",
-			UpstreamURL: "http://example.com/foo/bar/",
+			UpstreamURL: "",
 		},
 	}
 	err = fsRepo.Add(defToAdd)

--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/asaskevich/govalidator"
 	"github.com/hellofresh/janus/pkg/errors"
 	"github.com/hellofresh/janus/pkg/notifier"
 	"github.com/hellofresh/janus/pkg/opentracing"
@@ -116,6 +117,12 @@ func (c *Controller) PutBy() http.HandlerFunc {
 func (c *Controller) Post() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		definition := NewDefinition()
+
+		_, vErr := govalidator.ValidateStruct(definition)
+		if nil != vErr {
+			errors.Handler(w, ErrUpstreamURLdeprecated)
+			return
+		}
 
 		err := json.NewDecoder(r.Body).Decode(definition)
 		if nil != err {

--- a/pkg/api/in_memory_repository_test.go
+++ b/pkg/api/in_memory_repository_test.go
@@ -14,7 +14,7 @@ func newInMemoryRepo() *InMemoryRepository {
 		Name: "test1",
 		Proxy: &proxy.Definition{
 			ListenPath:  "/test1",
-			UpstreamURL: "http://test1",
+			UpstreamURL: "",
 		},
 		HealthCheck: HealthCheck{
 			URL:     "http://test1.com/status",
@@ -26,7 +26,7 @@ func newInMemoryRepo() *InMemoryRepository {
 		Name: "test2",
 		Proxy: &proxy.Definition{
 			ListenPath:  "/test2",
-			UpstreamURL: "http://test2",
+			UpstreamURL: "",
 		},
 	})
 
@@ -38,7 +38,7 @@ func TestExists(t *testing.T) {
 		Name: "test3",
 		Proxy: &proxy.Definition{
 			ListenPath:  "/test3",
-			UpstreamURL: "http://test3",
+			UpstreamURL: "",
 		},
 	}
 	repo := newInMemoryRepo()

--- a/pkg/api/mongodb_repository.go
+++ b/pkg/api/mongodb_repository.go
@@ -69,13 +69,7 @@ func (r *MongoRepository) Exists(def *Definition) (bool, error) {
 func (r *MongoRepository) Add(definition *Definition) error {
 	session, coll := r.getSession()
 	defer session.Close()
-
-	isValid, err := definition.Validate()
-	if false == isValid && err != nil {
-		log.WithError(err).Error("Validation errors")
-		return err
-	}
-
+	var err error
 	_, err = coll.Upsert(bson.M{"name": definition.Name}, definition)
 	if err != nil {
 		log.WithField("name", definition.Name).Error("There was an error adding the resource")

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -27,7 +27,7 @@ func TestLoadValidAPIDefinitions(t *testing.T) {
 		Active: true,
 		Proxy: &proxy.Definition{
 			ListenPath:  "/test1",
-			UpstreamURL: "http://test1",
+			UpstreamURL: "",
 			Methods:     []string{http.MethodGet},
 		},
 		Plugins: []api.Plugin{
@@ -51,7 +51,7 @@ func TestLoadValidAPIDefinitions(t *testing.T) {
 		Active: true,
 		Proxy: &proxy.Definition{
 			ListenPath:  "/test2",
-			UpstreamURL: "http://test2",
+			UpstreamURL: "",
 			Methods:     []string{http.MethodGet},
 		},
 	})
@@ -70,7 +70,7 @@ func TestLoadInvalidAPIDefinitions(t *testing.T) {
 		Active: true,
 		Proxy: &proxy.Definition{
 			ListenPath:  "/test2",
-			UpstreamURL: "http://test2",
+			UpstreamURL: "",
 			Methods:     []string{http.MethodGet},
 		},
 	}
@@ -92,7 +92,7 @@ func TestLoadAPIDefinitionsMissingHTTPMethods(t *testing.T) {
 		Active: true,
 		Proxy: &proxy.Definition{
 			ListenPath:  "/test1",
-			UpstreamURL: "http://test1",
+			UpstreamURL: "",
 		},
 	})
 
@@ -110,7 +110,7 @@ func TestLoadInactiveAPIDefinitions(t *testing.T) {
 		Active: false,
 		Proxy: &proxy.Definition{
 			ListenPath:  "/test1",
-			UpstreamURL: "http://test1",
+			UpstreamURL: "",
 		},
 	})
 

--- a/pkg/proxy/definition.go
+++ b/pkg/proxy/definition.go
@@ -13,7 +13,7 @@ type Definition struct {
 	PreserveHost bool   `bson:"preserve_host" json:"preserve_host" mapstructure:"preserve_host"`
 	ListenPath   string `bson:"listen_path" json:"listen_path" mapstructure:"listen_path" valid:"required,urlpath"`
 	// Deprecated: Use Upstreams instead.
-	UpstreamURL         string     `bson:"upstream_url" json:"upstream_url" valid:"url"`
+	UpstreamURL         string     `bson:"upstream_url" json:"upstream_url" valid:"url,deprecated"`
 	Upstreams           *Upstreams `bson:"upstreams" json:"upstreams" mapstructure:"upstreams"`
 	InsecureSkipVerify  bool       `bson:"insecure_skip_verify" json:"insecure_skip_verify" mapstructure:"insecure_skip_verify"`
 	StripPath           bool       `bson:"strip_path" json:"strip_path" mapstructure:"strip_path"`
@@ -110,4 +110,13 @@ func init() {
 
 		return strings.Index(s, "/") == 0
 	})
+
+	govalidator.CustomTypeTagMap.Set("deprecated", func(i interface{}, o interface{}) bool {
+		s, ok := i.(string)
+		if !ok {
+			return false
+		}
+		return s == ""
+	})
+
 }

--- a/pkg/proxy/definition_test.go
+++ b/pkg/proxy/definition_test.go
@@ -14,7 +14,7 @@ func TestNewDefinitions(t *testing.T) {
 func TestSuccessfulValidation(t *testing.T) {
 	definition := Definition{
 		ListenPath:  "/*",
-		UpstreamURL: "http://test.com",
+		UpstreamURL: "",
 	}
 	isValid, err := definition.Validate()
 


### PR DESCRIPTION
## What does this PR do?
It makes API return a 400 HTTP code and the "message upstream_url is deprecated - please use upstreams instead" when user tries to create a proxy api definition with upstream_url set.

[govalidator](https://github.com/asaskevich/govalidator/pull/121) has an inbuilt way of specifying validation error, so used that to produce an error message, which looks like this:
```
{
    "error": "upstream_url is deprecated - please use upstreams instead;;;"
}
```
@italolelis, Happy to change this approach and use api's own error handling in `janus/pkg/api/error.go` if you show me how :)
