### PR TITLE
Combining Redis libraries

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -25,6 +25,12 @@
   version = "v3.0.0"
 
 [[projects]]
+  name = "github.com/alicebob/miniredis"
+  packages = [".","server"]
+  revision = "70cb3fab2cf658a95f2ccae5bfb2f0ccbba0c548"
+  version = "2.2.1"
+
+[[projects]]
   name = "github.com/asaskevich/govalidator"
   packages = ["."]
   revision = "7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877"
@@ -58,12 +64,6 @@
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
   revision = "4da3e2cfbabc9f751898f250b49f2439785783a1"
-
-[[projects]]
-  name = "github.com/garyburd/redigo"
-  packages = ["internal","redis"]
-  revision = "433969511232c397de61b1442f9fd49ec06ae9ba"
-  version = "v1.1.0"
 
 [[projects]]
   name = "github.com/go-chi/chi"
@@ -358,6 +358,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "31ddf58544e06f292bd3a97fb2ddb8b5e672d076ede7aa4bc835c2eabcefc1ea"
+  inputs-digest = "977dd918aaee8445c42180c2285e34fd2bdbb21691c7e796263c038e3b656c6b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -41,10 +41,6 @@
   version = "3.0.0"
 
 [[constraint]]
-  name = "github.com/garyburd/redigo"
-  version = "1.0.0"
-
-[[constraint]]
   name = "github.com/go-chi/chi"
   version = "3.0.0"
 
@@ -116,3 +112,7 @@
 [[constraint]]
   name = "github.com/go-redis/redis"
   version = "6.7.2"
+
+[[constraint]]
+  name = "github.com/alicebob/miniredis"
+  version = "2.2.1"

--- a/pkg/store/redis.go
+++ b/pkg/store/redis.go
@@ -2,8 +2,9 @@ package store
 
 import (
 	"encoding/json"
+	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/go-redis/redis"
 	"github.com/hellofresh/janus/pkg/notifier"
 	log "github.com/sirupsen/logrus"
 )
@@ -15,154 +16,82 @@ type RedisStore struct {
 	// The prefix to use for the key.
 	Prefix string
 
-	// github.com/garyburd/redigo Pool instance.
-	Pool *redis.Pool
+	// go-redis Client instance
+	Client *redis.Client
 
 	// The maximum number of retry under race conditions.
 	MaxRetry int
 }
 
 // NewRedisStore returns an instance of redis store.
-func NewRedisStore(pool *redis.Pool, prefix string) (Store, error) {
+func NewRedisStore(client *redis.Client, prefix string) (Store, error) {
 	if prefix == "" {
 		prefix = defaultPrefix
 	}
 
-	return NewRedisStoreWithOptions(pool, Options{
+	return NewRedisStoreWithOptions(client, Options{
 		Prefix: prefix,
 	})
 }
 
 // NewRedisStoreWithOptions returns an instance of redis store with custom options.
-func NewRedisStoreWithOptions(pool *redis.Pool, options Options) (Store, error) {
+func NewRedisStoreWithOptions(client *redis.Client, options Options) (Store, error) {
 	store := &RedisStore{
-		Pool:   pool,
+		Client: client,
 		Prefix: options.Prefix,
 	}
 
 	return store, nil
 }
 
-func (s *RedisStore) getConnection() redis.Conn {
-	return s.Pool.Get()
-}
-
 // ping checks if redis is alive.
 func (s *RedisStore) ping() (bool, error) {
-	conn := s.getConnection()
-	defer conn.Close()
-
-	data, err := conn.Do("PING")
-	if err != nil || data == nil {
-		return false, err
-	}
-
-	return data == "PONG", nil
+	data, err := s.Client.Ping().Result()
+	return data == "PONG", err
 }
 
 // Exists checks if a key exists in the store
 func (s *RedisStore) Exists(key string) (bool, error) {
-	conn := s.getConnection()
-	defer conn.Close()
-
-	return s.exists(conn, key)
+	data, err := s.Client.Exists(key).Result()
+	return data == 1, err
 }
 
 // Get retreives a value from the store
 func (s *RedisStore) Get(key string) (string, error) {
-	conn := s.getConnection()
-	defer conn.Close()
-
-	return s.get(conn, key)
+	return s.Client.Get(key).Result()
 }
 
 // Remove a value from the store
 func (s *RedisStore) Remove(key string) error {
-	conn := s.getConnection()
-	defer conn.Close()
-
-	return s.remove(conn, key)
+	return s.Client.Del(key).Err()
 }
 
 // Set a value in the store
 func (s *RedisStore) Set(key string, value string, expire int64) error {
-	conn := s.getConnection()
-	defer conn.Close()
-
-	return s.set(conn, key, value, expire)
+	return s.Client.Set(key, value, time.Duration(expire)*time.Second).Err()
 }
 
 // Publish publishes to a topic in redis
 func (s *RedisStore) Publish(topic string, data []byte) error {
-	c := s.getConnection()
-	_, err := c.Do("PUBLISH", topic, data)
-	return err
+	return s.Client.Publish(topic, data).Err()
 }
 
 // Subscribe subscribes to a topic in redis
 func (s *RedisStore) Subscribe(channel string, callback func(notifier.Notification)) error {
-	// Get a connection from a pool
-	c := s.getConnection()
-	defer c.Close()
-
-	psc := redis.PubSubConn{Conn: c}
-	if err := psc.Subscribe(channel); err != nil {
-		return err
-	}
+	pubsub := s.Client.Subscribe(channel)
+	defer pubsub.Close()
 
 	for {
-		switch v := psc.Receive().(type) {
-		case redis.Message:
-			notification := notifier.Notification{}
-			if err := json.Unmarshal(v.Data, &notification); err != nil {
-				log.WithError(err).Error("Unmarshalling message body failed, malformed")
-				return err
-			}
-			callback(notification)
-		case error:
-			log.WithError(v).Debug("An error occurred when getting the message")
-			return v
+		v, err := pubsub.ReceiveMessage()
+		if err != nil {
+			log.WithError(err).Debug("An error occurred when getting the message")
+			return err
 		}
+		notification := notifier.Notification{}
+		if marshallErr := json.Unmarshal([]byte(v.Payload), &notification); marshallErr != nil {
+			log.WithError(marshallErr).Error("Unmarshalling message body failed, malformed")
+			return marshallErr
+		}
+		callback(notification)
 	}
-}
-
-func (s *RedisStore) exists(conn redis.Conn, key string) (bool, error) {
-	exists, err := redis.Bool(conn.Do("EXISTS", key))
-	if err != nil {
-		return false, err
-	}
-
-	return exists, nil
-}
-
-func (s *RedisStore) remove(conn redis.Conn, key string) error {
-	_, err := conn.Do("DEL", key)
-	return err
-}
-
-func (s *RedisStore) get(conn redis.Conn, key string) (string, error) {
-	return redis.String(conn.Do("GET", key))
-}
-
-func (s *RedisStore) set(conn redis.Conn, key string, value string, expire int64) error {
-	command, args := getSetCommandAndArgs(key, value, expire)
-	if _, err := conn.Do(command, args...); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func getSetCommandAndArgs(key string, value string, expire int64) (string, []interface{}) {
-	var args []interface{}
-	if expire == 0 {
-		args = append(args, key)
-		args = append(args, value)
-		return "SET", args
-	}
-
-	args = append(args, key)
-	args = append(args, expire)
-	args = append(args, value)
-	return "SETEX", args
 }

--- a/pkg/store/redis_test.go
+++ b/pkg/store/redis_test.go
@@ -1,165 +1,105 @@
 package store
 
 import (
-	"errors"
 	"testing"
+	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/alicebob/miniredis"
+	"github.com/go-redis/redis"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-type mockConnDoAssert struct {
-	t        *testing.T
-	command  string
-	args     []interface{}
-	doResult interface{}
-	doError  error
+type RedisTestSuite struct {
+	suite.Suite
+	redisServer *miniredis.Miniredis
+	redisStore  Store
 }
 
-func (conn mockConnDoAssert) Do(command string, args ...interface{}) (interface{}, error) {
-	assert.Equal(conn.t, conn.command, command)
-	assert.Len(conn.t, args, len(conn.args))
-	for idx, val := range args {
-		assert.Equal(conn.t, conn.args[idx], val)
-	}
-	return conn.doResult, conn.doError
-}
-func (conn mockConnDoAssert) Send(string, ...interface{}) error { return nil }
-func (conn mockConnDoAssert) Err() error                        { return nil }
-func (conn mockConnDoAssert) Close() error                      { return nil }
-func (conn mockConnDoAssert) Flush() error                      { return nil }
-func (conn mockConnDoAssert) Receive() (interface{}, error)     { return nil, nil }
+func (suite *RedisTestSuite) SetupTest() {
+	server, err := miniredis.Run()
+	suite.Nil(err)
+	suite.redisServer = server
 
-type mockRedisStore struct {
-	conn       redis.Conn
-	redisStore *RedisStore
+	client := redis.NewClient(&redis.Options{
+		Addr:        suite.redisServer.Addr(),
+		DB:          0,
+		PoolSize:    3,
+		IdleTimeout: 240 * time.Second,
+	})
+	store, err := NewRedisStore(client, "testPrefix")
+	suite.Nil(err)
+	suite.redisStore = store
 }
 
-func newMockRedisStore(conn redis.Conn) *mockRedisStore {
-	return &mockRedisStore{conn: conn, redisStore: &RedisStore{}}
+func (suite *RedisTestSuite) TearDownTest() {
+	suite.redisStore = nil
+	suite.redisServer.Close()
+	suite.redisServer = nil
 }
 
-func (s *mockRedisStore) getConnection() redis.Conn {
-	return s.conn
+func (suite *RedisTestSuite) TestSet() {
+	assert.Nil(suite.T(), suite.redisStore.Set(testKey, testValue, 0))
+	suite.redisServer.CheckGet(suite.T(), testKey, testValue)
 }
 
-func (s *mockRedisStore) Exists(key string) (bool, error) {
-	conn := s.getConnection()
-	defer conn.Close()
-
-	return s.redisStore.exists(conn, key)
+func (suite *RedisTestSuite) TestSetEx() {
+	assert.Nil(suite.T(), suite.redisStore.Set(testKey, testValue, 20))
+	suite.redisServer.CheckGet(suite.T(), testKey, testValue)
+	// Still exists after 10 seconds
+	suite.redisServer.FastForward(10 * time.Second)
+	assert.True(suite.T(), suite.redisServer.Exists(testKey))
+	suite.redisServer.CheckGet(suite.T(), testKey, testValue)
+	// Doesn't exists after 21 seconds (total)
+	suite.redisServer.FastForward(11 * time.Second)
+	assert.False(suite.T(), suite.redisServer.Exists(testKey))
 }
 
-func (s *mockRedisStore) Get(key string) (string, error) {
-	conn := s.getConnection()
-	defer conn.Close()
+func (suite *RedisTestSuite) TestGet() {
+	suite.redisServer.Set(testKey, testValue)
+	value, err := suite.redisStore.Get(testKey)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), value, testValue)
 
-	return s.redisStore.get(conn, key)
+	_, err = suite.redisStore.Get("DoesntExists")
+	assert.NotNil(suite.T(), err)
 }
 
-func (s *mockRedisStore) Remove(key string) error {
-	conn := s.getConnection()
-	defer conn.Close()
+func (suite *RedisTestSuite) TestExists() {
+	// Key doesn't exist yet
+	exists, err := suite.redisStore.Exists(testKey)
+	assert.Nil(suite.T(), err)
+	assert.False(suite.T(), exists)
 
-	return s.redisStore.remove(conn, key)
+	// Set the key and check existance
+	suite.redisServer.Set(testKey, testValue)
+	exists, err = suite.redisStore.Exists(testKey)
+	assert.Nil(suite.T(), err)
+	assert.True(suite.T(), exists)
+
+	// Try closing the server and see we receive an error
+	suite.redisServer.Close()
+	exists, err = suite.redisStore.Exists(testKey)
+	assert.NotNil(suite.T(), err)
+	assert.False(suite.T(), exists)
 }
 
-func (s *mockRedisStore) Set(key string, value string, expire int64) error {
-	conn := s.getConnection()
-	defer conn.Close()
+func (suite *RedisTestSuite) TestRemove() {
+	suite.redisServer.Set(testKey, testValue)
+	// Check it exists
+	value, err := suite.redisStore.Get(testKey)
+	assert.Equal(suite.T(), value, testValue)
+	assert.Nil(suite.T(), err)
 
-	return s.redisStore.set(conn, key, value, expire)
+	// Able to remove
+	assert.Nil(suite.T(), suite.redisStore.Remove(testKey))
+
+	// Doesn't exist anymore
+	value, err = suite.redisStore.Get(testKey)
+	assert.Empty(suite.T(), value)
+	assert.NotNil(suite.T(), err)
 }
 
-func TestRedisStore_getSetCommandAndArgs(t *testing.T) {
-	command, args := getSetCommandAndArgs(testKey, testValue, 0)
-	assert.Equal(t, "SET", command)
-	assert.Len(t, args, 2)
-	assert.Equal(t, testKey, args[0])
-	assert.Equal(t, testValue, args[1])
-
-	seconds := 3600
-	command, args = getSetCommandAndArgs(testKey, testValue, int64(seconds))
-	assert.Equal(t, "SETEX", command)
-	assert.Len(t, args, 3)
-	assert.Equal(t, testKey, args[0])
-	assert.Equal(t, int64(seconds), args[1])
-	assert.Equal(t, testValue, args[2])
-}
-
-func TestRedisStore_Set(t *testing.T) {
-	var argsSet []interface{}
-	argsSet = append(argsSet, testKey)
-	argsSet = append(argsSet, testValue)
-
-	connectionSet := mockConnDoAssert{t: t, command: "SET", args: argsSet, doResult: nil, doError: nil}
-	instanceSet := newMockRedisStore(connectionSet)
-	assert.Nil(t, instanceSet.Set(testKey, testValue, 0))
-
-	seconds := int64(3600)
-	var argsSetEx []interface{}
-	argsSetEx = append(argsSetEx, testKey)
-	argsSetEx = append(argsSetEx, seconds)
-	argsSetEx = append(argsSetEx, testValue)
-
-	connectionSetEx := mockConnDoAssert{t: t, command: "SETEX", args: argsSetEx, doResult: nil, doError: nil}
-	instanceSetEx := newMockRedisStore(connectionSetEx)
-	assert.Nil(t, instanceSetEx.Set(testKey, testValue, seconds))
-}
-
-func TestInMemoryStore_Set_week(t *testing.T) {
-	seconds := int64(2629743)
-	var argsSetEx []interface{}
-	argsSetEx = append(argsSetEx, testKey)
-	argsSetEx = append(argsSetEx, seconds)
-	argsSetEx = append(argsSetEx, testValue)
-
-	connectionSetEx := mockConnDoAssert{t: t, command: "SETEX", args: argsSetEx, doResult: nil, doError: nil}
-	instanceSetEx := newMockRedisStore(connectionSetEx)
-	assert.Nil(t, instanceSetEx.Set(testKey, testValue, seconds))
-}
-
-func TestRedisStore_Get(t *testing.T) {
-	var argsSet []interface{}
-	argsSet = append(argsSet, testKey)
-	connection := mockConnDoAssert{t: t, command: "GET", args: argsSet, doResult: testValue, doError: nil}
-	instance := newMockRedisStore(connection)
-
-	val, err := instance.Get(testKey)
-	assert.Nil(t, err)
-	assert.Equal(t, testValue, val)
-}
-
-func TestRedisStore_Exists(t *testing.T) {
-	var argsSet []interface{}
-	argsSet = append(argsSet, testKey)
-
-	connectionTrue := mockConnDoAssert{t: t, command: "EXISTS", args: argsSet, doResult: int64(1), doError: nil}
-	instanceTrue := newMockRedisStore(connectionTrue)
-
-	val, err := instanceTrue.Exists(testKey)
-	assert.Nil(t, err)
-	assert.True(t, val)
-
-	connectionFalse := mockConnDoAssert{t: t, command: "EXISTS", args: argsSet, doResult: int64(0), doError: nil}
-	instanceFalse := newMockRedisStore(connectionFalse)
-	val, err = instanceFalse.Exists(testKey)
-	assert.Nil(t, err)
-	assert.False(t, val)
-
-	connectionError := mockConnDoAssert{t: t, command: "EXISTS", args: argsSet, doResult: int64(0), doError: errors.New("")}
-	instanceError := newMockRedisStore(connectionError)
-	val, err = instanceError.Exists(testKey)
-	assert.NotNil(t, err)
-	assert.False(t, val)
-}
-
-func TestRedisStore_Remove(t *testing.T) {
-	var argsRemove []interface{}
-	argsRemove = append(argsRemove, testKey)
-	connection := mockConnDoAssert{t: t, command: "DEL", args: argsRemove, doError: nil}
-	instance := newMockRedisStore(connection)
-
-	err := instance.Remove(testKey)
-	assert.Nil(t, err)
+func TestRedisTestSuite(t *testing.T) {
+	suite.Run(t, new(RedisTestSuite))
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/go-redis/redis"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -48,15 +48,17 @@ func Build(dsn string) (Store, error) {
 	case InMemory:
 		return NewInMemoryStore(), nil
 	case Redis:
-		// Create a Redis pool.
-		pool := &redis.Pool{
-			MaxIdle:     3,
-			IdleTimeout: 240 * time.Second,
-			Dial:        func() (redis.Conn, error) { return redis.DialURL(dsn) },
+		// Create a Redis client.
+		option, err := redis.ParseURL(dsn)
+		if err != nil {
+			return nil, err
 		}
+		option.PoolSize = 3
+		option.IdleTimeout = 240 * time.Second
+		client := redis.NewClient(option)
 
 		log.WithField("dsn", dsn).Debug("Trying to connect to redis pool")
-		return NewRedisStore(pool, dsnURL.Query().Get("prefix"))
+		return NewRedisStore(client, dsnURL.Query().Get("prefix"))
 	}
 
 	return nil, ErrUnknownStorage


### PR DESCRIPTION
## What does this PR do?
Migrating the store code to use _go-redis/redis_ instead of _garyburd/redigo_, as the former is required for _ulule/limiter_.
This resolves hellofresh/janus#220

## What was changed?
- Changed the `RedisStore` implementation to work directly with _go-redis_'s package methods (Set/Get/Exists...).
- Redis pool is automatically managed through _go-redis_'s connection options, so no need to fetch a connection and close it at the end of usage.
- Rewrote the `RedisStore` tests to use [alicebob/miniredis](https://github.com/alicebob/miniredis) for unit testing.
- Removed _redigo_'s references from the code

## Other
I didn't see #222 before creating this pull request, so I can remove this pull request if asked. (Although this PR includes unit tests for the store.)