### PR TITLE
Improve error msg health check

### DIFF
--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -114,7 +114,7 @@ func check(definition *api.Definition) func() error {
 	return func() error {
 		resp, err := doStatusRequest(definition, true)
 		if err != nil {
-			return err
+			return fmt.Errorf("%s health check endpoint %s is unreachable", definition.Name, definition.HealthCheck.URL)
 		}
 
 		if resp.StatusCode >= http.StatusInternalServerError {


### PR DESCRIPTION
Expose a more understandable error message when users registers either wrong or invalid health-check url,

So before error was like:
```
 http://davor_qa.io/healthcheck: dial tcp: lookup davor_qa.io on 172.16.0.2:53: no such host
```

Now it is:
```
davor_qa.io health check endpoint http://davor_qa.io/healthcheck is unreachable
```
