### PR TITLE
Implement pub-sub for storage in memory

### DIFF
--- a/pkg/notifier/listener.go
+++ b/pkg/notifier/listener.go
@@ -19,20 +19,20 @@ func NewNotificationListener(subscriber Subscriber) *NotificationListener {
 // Start starts listening for signals on the cluster
 func (n *NotificationListener) Start(fn func(v Notification)) {
 	log.Debug("Listening for change events")
+	logWithFields := log.WithFields(log.Fields{
+		"prefix": "pub-sub",
+	})
 
 	go func() {
 		for {
-			err := n.subscriber.Subscribe(DefaultChannel, fn)
-			if err != nil {
-				log.WithFields(log.Fields{
-					"prefix": "pub-sub",
-					"err":    err,
-				}).Error("Connection failed, reconnect in 10s")
+			if err := n.subscriber.Subscribe(DefaultChannel, fn); err != nil {
+				logWithFields.
+					WithError(err).
+					Error("Connection failed, reconnect in 10s")
 
 				time.Sleep(10 * time.Second)
-				log.WithFields(log.Fields{
-					"prefix": "pub-sub",
-				}).Warning("Reconnecting")
+
+				logWithFields.Warning("Reconnecting")
 			}
 		}
 	}()

--- a/pkg/store/in_memory.go
+++ b/pkg/store/in_memory.go
@@ -1,11 +1,16 @@
 package store
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/hellofresh/janus/pkg/notifier"
+)
 
 // InMemoryStore is the redis store.
 type InMemoryStore struct {
 	sync.Mutex
-	data map[string]string
+	data   map[string]string
+	client chan struct{}
 }
 
 // NewInMemoryStore returns an instance of memory store.
@@ -16,7 +21,8 @@ func NewInMemoryStore() *InMemoryStore {
 // NewInMemoryStoreWithOptions returns an instance of memory store with custom options.
 func NewInMemoryStoreWithOptions() *InMemoryStore {
 	return &InMemoryStore{
-		data: make(map[string]string),
+		data:   make(map[string]string),
+		client: make(chan struct{}),
 	}
 }
 
@@ -50,6 +56,21 @@ func (s *InMemoryStore) Set(key string, value string, expire int64) error {
 	defer s.Unlock()
 
 	return s.set(key, value, expire)
+}
+
+// Publish publishes in memory
+func (s *InMemoryStore) Publish(topic string, data []byte) error {
+	s.client <- struct{}{}
+	return nil
+}
+
+// Subscribe subscribes to messages in memory
+func (s *InMemoryStore) Subscribe(channel string, callback func(notifier.Notification)) error {
+	for range s.client {
+		notification := notifier.Notification{}
+		callback(notification)
+	}
+	return nil
 }
 
 func (s *InMemoryStore) exists(key string) (bool, error) {

--- a/pkg/store/in_memory_test.go
+++ b/pkg/store/in_memory_test.go
@@ -11,23 +11,54 @@ const (
 	testValue = "value"
 )
 
-func TestInMemoryStore_NewInMemoryStore(t *testing.T) {
-	instance := NewInMemoryStore()
+func TestInMemoryStore(t *testing.T) {
+	t.Parallel()
 
+	tests := []struct {
+		scenario string
+		function func(*testing.T, *InMemoryStore)
+	}{
+		{
+			scenario: "new in memory store",
+			function: testNewInMemoryStore,
+		},
+		{
+			scenario: "set in memory store",
+			function: testInMemoryStoreSet,
+		},
+		{
+			scenario: "check exists from in memory store",
+			function: testInMemoryStoreExists,
+		},
+		{
+			scenario: "get from in memory store",
+			function: testInMemoryStoreGet,
+		},
+		{
+			scenario: "remove from in memory store",
+			function: testInMemoryStoreRemove,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			instance := NewInMemoryStore()
+			test.function(t, instance)
+		})
+	}
+}
+
+func testNewInMemoryStore(t *testing.T, instance *InMemoryStore) {
 	assert.IsType(t, &InMemoryStore{}, instance)
 	assert.Implements(t, (*Store)(nil), instance)
 }
 
-func TestInMemoryStore_Set(t *testing.T) {
-	instance := NewInMemoryStore()
-
+func testInMemoryStoreSet(t *testing.T, instance *InMemoryStore) {
 	err := instance.Set(testKey, testValue, 0)
 	assert.Nil(t, err)
 }
 
-func TestInMemoryStore_Exists(t *testing.T) {
-	instance := NewInMemoryStore()
-
+func testInMemoryStoreExists(t *testing.T, instance *InMemoryStore) {
 	instance.Set(testKey, testValue, 0)
 
 	val, err := instance.Exists("foo")
@@ -39,9 +70,7 @@ func TestInMemoryStore_Exists(t *testing.T) {
 	assert.True(t, val)
 }
 
-func TestInMemoryStore_Get(t *testing.T) {
-	instance := NewInMemoryStore()
-
+func testInMemoryStoreGet(t *testing.T, instance *InMemoryStore) {
 	instance.Set(testKey, testValue, 0)
 
 	val, err := instance.Get(testKey)
@@ -53,9 +82,7 @@ func TestInMemoryStore_Get(t *testing.T) {
 	assert.Empty(t, val)
 }
 
-func TestInMemoryStore_Remove(t *testing.T) {
-	instance := NewInMemoryStore()
-
+func testInMemoryStoreRemove(t *testing.T, instance *InMemoryStore) {
 	instance.Set(testKey, testValue, 0)
 
 	val, err := instance.Get(testKey)


### PR DESCRIPTION
This PR Implements a pub-sub mechanism for in memory storage `STORAGE_DSN=memory://localhost:6379`. This way while I change the proxy definition via API I instantly see the changes and no need for redeploying the server