### PR TITLE
Support url parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Jaeger support as distributed tracing backend
 - Added Proxy Listen Path validation to prevent `chi` from panicking in case of invalid listen path
 - Added load balancing for upstream targets. Now you can add multiple upstream targets and Janus will balance the requests.
+- Added support for url parameters both in listen path and upstreams.
 
 ## Fixed
 

--- a/assets/stubs/mappings/recipes-menu.json
+++ b/assets/stubs/mappings/recipes-menu.json
@@ -1,0 +1,13 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPathPattern": "/recipes/5252b1b5301bbf46038b473f/menus/6362b1b5301bbf46038b4766"
+    },
+    "response": {
+        "status": 200,
+        "headers": {
+            "Content-Type": "application/json; charset=utf-8"
+        },
+        "jsonBody": {"description": "A menu description"}
+    }
+}

--- a/assets/stubs/mappings/recipes.json
+++ b/assets/stubs/mappings/recipes.json
@@ -1,0 +1,13 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPathPattern": "/recipes/5252b1b5301bbf46038b473f"
+    },
+    "response": {
+        "status": 200,
+        "headers": {
+            "Content-Type": "application/json; charset=utf-8"
+        },
+        "jsonBody": {"slug": "I'm a slug"}
+    }
+}

--- a/docs/proxy/routing_capabilities.md
+++ b/docs/proxy/routing_capabilities.md
@@ -83,3 +83,21 @@ Now that we understand how the hosts, uris, and methods properties work together
     }
 }
 ```
+
+*Named url parameters:* you can have named parameters inside your upstream and then specify where they should be in the targets, like the following:
+```json
+{
+    "name": "My API",
+    "proxy": {
+        "listen_path": "/myresource/{id:[\\da-f]{24}}",
+        "upstreams" : {
+            "balancing": "roundrobin",
+            "targets": [
+                {"target": "http://my-application.com/api/myresource/{id}"}
+            ]
+        },
+        "methods": ["GET"]
+    }
+}
+```
+When you define a parameter in the upstream you can provide regex to match a pattern, then when you define the target you can put the parameter anywhere you like.

--- a/features/Proxy.feature
+++ b/features/Proxy.feature
@@ -207,3 +207,75 @@ Feature: Proxy requests to upstream.
 
         When I request "/posts-public/nested/path" path with "GET" method
         Then I should receive 404 response code
+
+        Given request JSON payload:
+            """
+            {
+                "name":"one parameter",
+                "active":true,
+                "proxy":{
+                    "preserve_host":false,
+                    "listen_path":"/api/recipes/{id:[\\da-f]{24}}",
+                    "upstreams":{
+                        "balancing":"roundrobin",
+                        "targets":[
+                            {
+                                "target":"http://localhost:9089/recipes/{id}"
+                            }
+                        ]
+                    },
+                    "strip_path":false,
+                    "append_path":false,
+                    "enable_load_balancing":false,
+                    "methods":[
+                        "GET"
+                    ]
+                },
+                "health_check":{
+                    "url":"https://example.com/status"
+                }
+            }
+            """
+        When I request "/apis" API path with "POST" method
+        Then I should receive 201 response code
+
+        When I wait for a while
+        And I request "/api/recipes/5252b1b5301bbf46038b473f" path with "GET" method
+        Then I should receive 200 response code
+        And the response should contain "I'm a slug"
+
+        Given request JSON payload:
+            """
+            {
+                "name":"two parameters",
+                "active":true,
+                "proxy":{
+                    "preserve_host":false,
+                    "listen_path":"/api/recipes/{recipeId:[\\da-f]{24}}/menus/{menuId:[\\da-f]{24}}",
+                    "upstreams":{
+                        "balancing":"roundrobin",
+                        "targets":[
+                            {
+                                "target":"http://localhost:9089/recipes/{recipeId}/menus/{menuId}"
+                            }
+                        ]
+                    },
+                    "strip_path":false,
+                    "append_path":false,
+                    "enable_load_balancing":false,
+                    "methods":[
+                        "GET"
+                    ]
+                },
+                "health_check":{
+                    "url":"https://example.com/status"
+                }
+            }
+            """
+        When I request "/apis" API path with "POST" method
+        Then I should receive 201 response code
+
+        When I wait for a while
+        And I request "/api/recipes/5252b1b5301bbf46038b473f/menus/6362b1b5301bbf46038b4766" path with "GET" method
+        Then I should receive 200 response code
+        And the response should contain "A menu description"

--- a/pkg/router/listen_path_parameter_name_extractor.go
+++ b/pkg/router/listen_path_parameter_name_extractor.go
@@ -1,0 +1,29 @@
+package router
+
+import "regexp"
+
+const (
+	parameterMatchRule = `\{([^/}]+)\}`
+)
+
+// ListenPathParameterNameExtractor is responsible for extracting parameters name from the listen path
+type ListenPathParameterNameExtractor struct {
+	reg *regexp.Regexp
+}
+
+// NewListenPathParamNameExtractor creates a new instance ListenPathParameterNameExtractor
+func NewListenPathParamNameExtractor() *ListenPathParameterNameExtractor {
+	return &ListenPathParameterNameExtractor{regexp.MustCompile(parameterMatchRule)}
+}
+
+// Extract takes the usable part of the listen path and extracts parameter names
+func (l *ListenPathParameterNameExtractor) Extract(listenPath string) []string {
+	submatches := l.reg.FindAllStringSubmatch(listenPath, -1)
+	result := make([]string, 0, len(submatches))
+
+	for _, submatch := range submatches {
+		result = append(result, submatch[1])
+	}
+
+	return result
+}

--- a/pkg/router/listen_path_parameter_name_extractor_test.go
+++ b/pkg/router/listen_path_parameter_name_extractor_test.go
@@ -1,0 +1,18 @@
+package router_test
+
+import (
+	"testing"
+
+	"github.com/hellofresh/janus/pkg/router"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractCorrectParameters(t *testing.T) {
+	extractor := router.NewListenPathParamNameExtractor()
+
+	assert.Equal(t, []string{}, extractor.Extract("/recipes/"))
+	assert.Equal(t, []string{}, extractor.Extract("/recipes?take=100"))
+	assert.Equal(t, []string{"id"}, extractor.Extract("/recipes/{id}/favorites"))
+	assert.Equal(t, []string{"id", "slug"}, extractor.Extract("/recipes/{id}/favorites/{slug}"))
+	assert.Equal(t, []string{"id", "slug"}, extractor.Extract("/recipes/{id}/favorites/{slug}?q=123"))
+}


### PR DESCRIPTION
## What does this PR do?
Adds supports for named parameters in the target url.

**Example**
Given this configuration
```
Definition{
	ListenPath: "/api/recipes/{id:[\\da-f]{24}}",
	Upstreams: &Upstreams{
		Balancing: "roundrobin",
		Targets:   []*Target{{Target: "http://localhost:9089/recipes/{id}"}},
	},
	Methods:    []string{"ALL"},
	StripPath:  false,
	AppendPath: false,
}
```

If I call `/api/recipes/5252b1b5301bbf46038b473f` my call should be forwarded to `http://localhost:9089/recipes/5252b1b5301bbf46038b473f`