### PR TITLE
Add validation to (*Definition).Name

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -2,9 +2,11 @@ package api
 
 import (
 	"encoding/json"
+	"regexp"
 
 	"github.com/asaskevich/govalidator"
 	"github.com/hellofresh/janus/pkg/proxy"
+	"github.com/pkg/errors"
 )
 
 // Spec Holds an api definition and basic options
@@ -45,6 +47,13 @@ func NewDefinition() *Definition {
 
 // Validate validates proxy data
 func (d *Definition) Validate() (bool, error) {
+	r := regexp.MustCompile(`^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$`)
+
+	slug := r.MatchString(d.Name)
+	if !slug {
+		return false, errors.New("Name cannot contain non-URL friendly characters")
+	}
+
 	return govalidator.ValidateStruct(d)
 }
 

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -33,3 +33,12 @@ func TestFailedValidation(t *testing.T) {
 	assert.Error(t, err)
 	assert.False(t, isValid)
 }
+
+func TestNameFailedValidation(t *testing.T) {
+	instance := api.NewDefinition()
+	instance.Name = "test~"
+	isValid, err := instance.Validate()
+
+	assert.Error(t, err)
+	assert.False(t, isValid)
+}


### PR DESCRIPTION
## Why?
So that it cannot contain non-URL firendly chars.

## How?
By validating and matching against the pattern below:
/^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$/