### PR TITLE
Add token metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Unreleased
 
+## Added
+
+- Extra JWT metrics for token validation success and error
+
+## Fixed
+ 
+ - Fixed a bug for the `oauth servers` when rows were empty it was returnig `null` on the json reponse.
+ 
 # 3.5.0
 
 ## Added

--- a/pkg/jwt/handler.go
+++ b/pkg/jwt/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dgrijalva/jwt-go"
 	"github.com/hellofresh/janus/pkg/config"
 	"github.com/hellofresh/janus/pkg/jwt/provider"
+	"github.com/hellofresh/janus/pkg/opentracing"
 	"github.com/hellofresh/janus/pkg/render"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -29,7 +30,9 @@ type Handler struct {
 // Reply will be of the form {"token": "<TOKEN>"}.
 func (j *Handler) Login(config config.Credentials) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		span := opentracing.FromContext(r.Context(), "token.extract")
 		accessToken, err := extractAccessToken(r)
+		span.Finish()
 		if err != nil {
 			log.WithError(err).Debug("failed to extract access token")
 		}
@@ -38,7 +41,9 @@ func (j *Handler) Login(config config.Credentials) http.HandlerFunc {
 		factory := provider.Factory{}
 		p := factory.Build(r.URL.Query().Get("provider"), config)
 
+		span = opentracing.FromContext(r.Context(), "token.verify")
 		verified, err := p.Verify(r, httpClient)
+		span.Finish()
 		if err != nil || !verified {
 			log.WithError(err).Debug(err.Error())
 			render.JSON(w, http.StatusUnauthorized, err.Error())
@@ -55,7 +60,9 @@ func (j *Handler) Login(config config.Credentials) http.HandlerFunc {
 			return
 		}
 
+		span = opentracing.FromContext(r.Context(), "token.issue_admin")
 		token, err := IssueAdminToken(j.Guard.SigningMethod, claims, j.Guard.Timeout)
+		span.Finish()
 		if err != nil {
 			render.JSON(w, http.StatusUnauthorized, "problem issuing JWT")
 			return

--- a/pkg/jwt/parser.go
+++ b/pkg/jwt/parser.go
@@ -128,7 +128,7 @@ func (jp *Parser) Parse(tokenString string) (*jwt.Token, error) {
 				continue
 			}
 
-			if validationErr, ok := err.(jwt.ValidationError); ok && validationErr.Errors&jwt.ValidationErrorSignatureInvalid != 0 {
+			if validationErr, ok := err.(*jwt.ValidationError); ok && (validationErr.Errors&jwt.ValidationErrorUnverifiable > 0 || validationErr.Errors&jwt.ValidationErrorSignatureInvalid > 0) {
 				continue
 			}
 		}

--- a/pkg/jwt/parser.go
+++ b/pkg/jwt/parser.go
@@ -124,7 +124,13 @@ func (jp *Parser) Parse(tokenString string) (*jwt.Token, error) {
 		})
 
 		if err != nil {
-			continue
+			if err == ErrSigningMethodMismatch {
+				continue
+			}
+
+			if validationErr, ok := err.(jwt.ValidationError); ok && validationErr.Errors&jwt.ValidationErrorSignatureInvalid != 0 {
+				continue
+			}
 		}
 
 		return token, err

--- a/pkg/jwt/parser_test.go
+++ b/pkg/jwt/parser_test.go
@@ -92,7 +92,7 @@ func TestParser_Parse(t *testing.T) {
 	req := &http.Request{Header: http.Header{"Authorization": {"Bearer " + tokenString}}}
 
 	_, err = parser.ParseFromRequest(req)
-	assert.Equal(t, ErrFailedToParseToken, err)
+	require.Error(t, err)
 
 	parser.Config.SigningMethods = append(parser.Config.SigningMethods, SigningMethod{Alg: alg, Key: rsa2048Public})
 

--- a/pkg/metrics/metrics_context.go
+++ b/pkg/metrics/metrics_context.go
@@ -1,0 +1,26 @@
+package metrics
+
+import (
+	"context"
+
+	stats "github.com/hellofresh/stats-go"
+)
+
+type statsKeyType int
+
+const statsKey statsKeyType = iota
+
+// NewContext returns a context that has a stats Client
+func NewContext(ctx context.Context, client stats.Client) context.Context {
+	return context.WithValue(ctx, statsKey, client)
+}
+
+// WithContext returns a stats Client with as much context as possible
+func WithContext(ctx context.Context) stats.Client {
+	ctxStats, ok := ctx.Value(statsKey).(stats.Client)
+	if !ok {
+		ctxStats, _ := stats.NewClient("noop://", "")
+		return ctxStats
+	}
+	return ctxStats
+}

--- a/pkg/middleware/stats.go
+++ b/pkg/middleware/stats.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"sync"
 
+	"github.com/hellofresh/janus/pkg/metrics"
 	"github.com/hellofresh/janus/pkg/response"
 	"github.com/hellofresh/stats-go"
 	log "github.com/sirupsen/logrus"
@@ -31,6 +32,7 @@ func (m *Stats) Handler(handler http.Handler) http.Handler {
 		)
 
 		log.WithField("path", r.URL.Path).Debug("Starting Stats middleware")
+		r.WithContext(metrics.NewContext(r.Context(), m.statsClient))
 
 		hooks := response.Hooks{
 			WriteHeader: func(next response.WriteHeaderFunc) response.WriteHeaderFunc {

--- a/pkg/plugin/oauth2/jwt_manager.go
+++ b/pkg/plugin/oauth2/jwt_manager.go
@@ -1,7 +1,13 @@
 package oauth2
 
 import (
+	"context"
+
+	jwtBase "github.com/dgrijalva/jwt-go"
 	"github.com/hellofresh/janus/pkg/jwt"
+	"github.com/hellofresh/janus/pkg/metrics"
+	stats "github.com/hellofresh/stats-go"
+	"github.com/hellofresh/stats-go/bucket"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -16,12 +22,41 @@ func NewJWTManager(parser *jwt.Parser) *JWTManager {
 }
 
 // IsKeyAuthorized checks if the access token is valid
-func (m *JWTManager) IsKeyAuthorized(accessToken string) bool {
-	_, err := m.parser.Parse(accessToken)
-	if err != nil {
-		log.WithError(err).Info("Failed to parse and validate the JWT")
+func (m *JWTManager) IsKeyAuthorized(ctx context.Context, accessToken string) bool {
+	if ctx == nil {
 		return false
 	}
 
+	stats := metrics.WithContext(ctx)
+	if stats == nil {
+		return false
+	}
+
+	if _, err := m.parser.Parse(accessToken); err != nil {
+		log.WithError(err).Info("Failed to parse and validate the JWT")
+
+		switch jwtErr := err.(type) {
+		case *jwtBase.ValidationError:
+			shouldReport(stats, jwtErr.Errors&jwtBase.ValidationErrorExpired != 0, "ValidationErrorExpired")
+			shouldReport(stats, jwtErr.Errors&jwtBase.ValidationErrorClaimsInvalid != 0, "ValidationErrorClaimsInvalid")
+			shouldReport(stats, jwtErr.Errors&jwtBase.ValidationErrorIssuedAt != 0, "ValidationErrorIssuedAt")
+			shouldReport(stats, jwtErr.Errors&jwtBase.ValidationErrorNotValidYet != 0, "ValidationErrorNotValidYet")
+			shouldReport(stats, jwtErr.Errors&jwtBase.ValidationErrorIssuer != 0, "ValidationErrorIssuer")
+			shouldReport(stats, jwtErr.Errors&jwtBase.ValidationErrorMalformed != 0, "ValidationErrorMalformed")
+			shouldReport(stats, jwtErr.Errors&jwtBase.ValidationErrorSignatureInvalid != 0, "ValidationErrorSignatureInvalid")
+			shouldReport(stats, jwtErr.Errors&jwtBase.ValidationErrorUnverifiable != 0, "ValidationErrorUnverifiable")
+			return false
+		default:
+			stats.TrackMetric("tokens", bucket.MetricOperation{"jwt-manager", "parse-error", "ErrFailedToParse"})
+			return false
+		}
+	}
+
 	return true
+}
+
+func shouldReport(client stats.Client, typeCheck bool, operation string) {
+	if typeCheck {
+		client.TrackMetric("tokens", bucket.MetricOperation{"jwt-manager", "parse-error", operation})
+	}
 }

--- a/pkg/plugin/oauth2/manager_factory.go
+++ b/pkg/plugin/oauth2/manager_factory.go
@@ -1,6 +1,7 @@
 package oauth2
 
 import (
+	"context"
 	"strings"
 
 	"github.com/hellofresh/janus/pkg/jwt"
@@ -36,7 +37,7 @@ type ManagerType uint8
 
 // Manager holds the methods to handle tokens
 type Manager interface {
-	IsKeyAuthorized(accessToken string) bool
+	IsKeyAuthorized(ctx context.Context, accessToken string) bool
 }
 
 // ManagerFactory is used for creating a new manager

--- a/pkg/plugin/oauth2/middleware.go
+++ b/pkg/plugin/oauth2/middleware.go
@@ -5,8 +5,15 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/hellofresh/stats-go/bucket"
+
 	"github.com/hellofresh/janus/pkg/errors"
+	"github.com/hellofresh/janus/pkg/metrics"
 	log "github.com/sirupsen/logrus"
+)
+
+const (
+	tokensSection = "tokens"
 )
 
 // Enums for keys to be stored in a session context - this is how gorilla expects
@@ -34,6 +41,8 @@ func NewKeyExistsMiddleware(manager Manager) func(http.Handler) http.Handler {
 	return func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			log.Debug("Starting Oauth2KeyExists middleware")
+			stats := metrics.WithContext(r.Context())
+
 			logger := log.WithFields(log.Fields{
 				"path":   r.RequestURI,
 				"origin": r.RemoteAddr,
@@ -44,18 +53,23 @@ func NewKeyExistsMiddleware(manager Manager) func(http.Handler) http.Handler {
 			parts := strings.Split(authHeaderValue, " ")
 			if len(parts) < 2 {
 				logger.Warn("Attempted access with malformed header, no auth header found.")
+				stats.TrackOperation(tokensSection, bucket.MetricOperation{"key-exists", "header"}, nil, false)
 				errors.Handler(w, ErrAuthorizationFieldNotFound)
 				return
 			}
+			stats.TrackOperation(tokensSection, bucket.MetricOperation{"key-exists", "header"}, nil, true)
 
 			if strings.ToLower(parts[0]) != "bearer" {
 				logger.Warn("Bearer token malformed")
+				stats.TrackOperation(tokensSection, bucket.MetricOperation{"key-exists", "malformed"}, nil, false)
 				errors.Handler(w, ErrBearerMalformed)
 				return
 			}
+			stats.TrackOperation(tokensSection, bucket.MetricOperation{"key-exists", "malformed"}, nil, true)
 
 			accessToken := parts[1]
-			keyExists := manager.IsKeyAuthorized(accessToken)
+			keyExists := manager.IsKeyAuthorized(r.Context(), accessToken)
+			stats.TrackOperation(tokensSection, bucket.MetricOperation{"key-exists", "authorized"}, nil, keyExists)
 
 			if !keyExists {
 				log.WithFields(log.Fields{

--- a/pkg/plugin/oauth2/middleware_test.go
+++ b/pkg/plugin/oauth2/middleware_test.go
@@ -1,6 +1,7 @@
 package oauth2
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -13,7 +14,7 @@ type mockManager struct {
 	authorized bool
 }
 
-func (m *mockManager) IsKeyAuthorized(accessToken string) bool {
+func (m *mockManager) IsKeyAuthorized(ctx context.Context, accessToken string) bool {
 	return m.authorized
 }
 

--- a/pkg/plugin/oauth2/mongodb_repository.go
+++ b/pkg/plugin/oauth2/mongodb_repository.go
@@ -38,10 +38,10 @@ func (r *MongoRepository) FindAll() ([]*OAuth, error) {
 	session, coll := r.getSession()
 	defer session.Close()
 
-	var result []*OAuth
+	result := []*OAuth{}
 	err := coll.Find(nil).All(&result)
 	if err != nil {
-		return nil, err
+		return result, err
 	}
 
 	return result, nil

--- a/pkg/plugin/oauth2/oauth_introspection.go
+++ b/pkg/plugin/oauth2/oauth_introspection.go
@@ -1,6 +1,7 @@
 package oauth2
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -29,7 +30,7 @@ func NewIntrospectionManager(url string, settings *IntrospectionSettings) (*Intr
 }
 
 // IsKeyAuthorized checks if the access token is valid
-func (o *IntrospectionManager) IsKeyAuthorized(accessToken string) bool {
+func (o *IntrospectionManager) IsKeyAuthorized(ctx context.Context, accessToken string) bool {
 	resp, err := o.doStatusRequest(accessToken)
 	defer resp.Body.Close()
 


### PR DESCRIPTION
## What does this PR do?

Adds more metrics to token validation. If it's a JWT we can be very precise about which kind of error to track on the metrics. This will allow you to build dashboards with metrics categories for each type of error.
