### PR TITLE
Added leeway support for JWT date fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Added
+
+- Leeway support for JWT date fields validation
+
 # 3.6.0
 
 ## Added

--- a/docs/auth/oauth.md
+++ b/docs/auth/oauth.md
@@ -79,7 +79,7 @@ Settings structure has the following format:
 ```
 
 List of signing methods allows signing method and keys rotation w/out immediate invalidation of the old one, so the
-tokens signed with ald and new methods will be valid.
+tokens signed with old and new methods will be valid.
 
 For backward compatibility the following settings format is also valid: `{"secret": "<key>"}` that is equal to the
 new format `[{"alg": "HS256", "key", "<key>"}]`.

--- a/docs/auth/oauth.md
+++ b/docs/auth/oauth.md
@@ -50,8 +50,9 @@ curl -X "GET" http://localhost:8080/auth/token?grant_type=client_credentials -H 
 | allowed_authorize_types       | The allowed authorize types for this oauth server                                         |
 | auth_login_redirect           | The auth login redirect URL                                                               |
 | secrets                       | A map of client_id: client_secret that allows you to authenticate only with the client_id |
-| token_strategy.name           | The token strategy for this server. Could be `introspection` or `jwt`                           |
-| token_strategy.settings       | Token strategy settings, see bellow by strategy              |
+| token_strategy.name           | The token strategy for this server. Could be `introspection` or `jwt`                     |
+| token_strategy.settings       | Token strategy settings, see bellow by strategy                                           |
+| token_strategy.leeway         | Token date fields validation leeway to solve clock skew problem                           |
 
 ## Token Strategy Settings
 

--- a/pkg/jwt/claims.go
+++ b/pkg/jwt/claims.go
@@ -1,0 +1,42 @@
+package jwt
+
+import (
+	"encoding/json"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+// JanusClaims is the temporary solution for JWT claims validation with leeway support,
+// should be removed as soon as github.com/dgrijalva/jwt-go 4.0 will be released with
+// leeway support out of the box. This code is loosely based on the solution from
+// https://github.com/dgrijalva/jwt-go/issues/131
+type JanusClaims struct {
+	jwt.MapClaims
+
+	leeway int64
+}
+
+// NewJanusClaims instantiates new JanusClaims
+func NewJanusClaims(leeway int64) *JanusClaims {
+	return &JanusClaims{MapClaims: jwt.MapClaims{}, leeway: leeway}
+}
+
+// UnmarshalJSON is Unmarshaler interface implementation for JanusClaims to unmarshal nested map claims correctly
+func (c *JanusClaims) UnmarshalJSON(text []byte) error {
+	return json.Unmarshal(text, &c.MapClaims)
+}
+
+// VerifyExpiresAt overrides jwt.StandardClaims.VerifyExpiresAt() to use leeway for check
+func (c *JanusClaims) VerifyExpiresAt(cmp int64, req bool) bool {
+	return c.MapClaims.VerifyExpiresAt(cmp-c.leeway, req)
+}
+
+// VerifyIssuedAt overrides jwt.StandardClaims.VerifyIssuedAt() to use leeway for check
+func (c *JanusClaims) VerifyIssuedAt(cmp int64, req bool) bool {
+	return c.MapClaims.VerifyIssuedAt(cmp+c.leeway, req)
+}
+
+// VerifyNotBefore overrides jwt.StandardClaims.VerifyNotBefore() to use leeway for check
+func (c *JanusClaims) VerifyNotBefore(cmp int64, req bool) bool {
+	return c.MapClaims.VerifyNotBefore(cmp+c.leeway, req)
+}

--- a/pkg/jwt/claims_test.go
+++ b/pkg/jwt/claims_test.go
@@ -1,0 +1,71 @@
+package jwt
+
+import (
+	"bytes"
+	"encoding/json"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJanusClaims_UnmarshalJSON(t *testing.T) {
+	claims := NewJanusClaims(0)
+
+	claimBytes := []byte(`{"exp":1,"iat":2,"iss":"test","username":"janus"}`)
+	dec := json.NewDecoder(bytes.NewBuffer(claimBytes))
+	err := dec.Decode(&claims)
+	require.NoError(t, err)
+
+	assert.Equal(t, float64(1), claims.MapClaims["exp"])
+	assert.Equal(t, float64(2), claims.MapClaims["iat"])
+	assert.Equal(t, "test", claims.MapClaims["iss"])
+	assert.Equal(t, "janus", claims.MapClaims["username"])
+}
+
+func TestJanusClaims_VerifyExpiresAt(t *testing.T) {
+	leeway := 1 + rand.Int63n(120)
+	claims := NewJanusClaims(leeway)
+	now := time.Now().Unix()
+
+	claims.MapClaims["exp"] = float64(now - 1)
+	assert.True(t, claims.VerifyExpiresAt(now, true))
+
+	claims.MapClaims["exp"] = float64(now - leeway)
+	assert.True(t, claims.VerifyExpiresAt(now, true))
+
+	claims.MapClaims["exp"] = float64(now - leeway - 1)
+	assert.False(t, claims.VerifyExpiresAt(now, true))
+}
+
+func TestJanusClaims_VerifyIssuedAt(t *testing.T) {
+	leeway := 1 + rand.Int63n(120)
+	claims := NewJanusClaims(leeway)
+	now := time.Now().Unix()
+
+	claims.MapClaims["iat"] = float64(now + 1)
+	assert.True(t, claims.VerifyIssuedAt(now, true))
+
+	claims.MapClaims["iat"] = float64(now + leeway)
+	assert.True(t, claims.VerifyIssuedAt(now, true))
+
+	claims.MapClaims["iat"] = float64(now + leeway + 1)
+	assert.False(t, claims.VerifyIssuedAt(now, true))
+}
+
+func TestJanusClaims_VerifyNotBefore(t *testing.T) {
+	leeway := 1 + rand.Int63n(120)
+	claims := NewJanusClaims(leeway)
+	now := time.Now().Unix()
+
+	claims.MapClaims["nbf"] = float64(now + 1)
+	assert.True(t, claims.VerifyNotBefore(now, true))
+
+	claims.MapClaims["nbf"] = float64(now + leeway)
+	assert.True(t, claims.VerifyNotBefore(now, true))
+
+	claims.MapClaims["nbf"] = float64(now + leeway + 1)
+	assert.False(t, claims.VerifyNotBefore(now, true))
+}

--- a/pkg/jwt/token_test.go
+++ b/pkg/jwt/token_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +17,7 @@ func TestIssueAdminToken(t *testing.T) {
 	accessToken, err := IssueAdminToken(SigningMethod{alg, key}, jwt.MapClaims{"id": claimsID}, time.Hour)
 	require.NoError(t, err)
 
-	config := NewParserConfig(SigningMethod{Alg: alg, Key: key})
+	config := NewParserConfig(0, SigningMethod{Alg: alg, Key: key})
 	parser := NewParser(config)
 
 	token, err := parser.Parse(accessToken.Token)

--- a/pkg/plugin/oauth2/jwt_manager_test.go
+++ b/pkg/plugin/oauth2/jwt_manager_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestJWTManagerValidKey(t *testing.T) {
 	signingMethod := jwt.SigningMethod{Alg: "HS256", Key: "secret"}
-	config := jwt.NewParserConfig(signingMethod)
+	config := jwt.NewParserConfig(0, signingMethod)
 	parser := jwt.NewParser(config)
 	manager := NewJWTManager(parser)
 
@@ -31,7 +31,7 @@ func TestJWTManagerValidKey(t *testing.T) {
 
 func TestJWTManagerInvalidKey(t *testing.T) {
 	signingMethod := jwt.SigningMethod{Alg: "HS256", Key: "secret"}
-	config := jwt.NewParserConfig(signingMethod)
+	config := jwt.NewParserConfig(0, signingMethod)
 	parser := jwt.NewParser(config)
 	manager := NewJWTManager(parser)
 
@@ -44,7 +44,7 @@ func TestJWTManagerInvalidKey(t *testing.T) {
 
 func TestJWTManagerNilContext(t *testing.T) {
 	signingMethod := jwt.SigningMethod{Alg: "HS256", Key: "secret"}
-	config := jwt.NewParserConfig(signingMethod)
+	config := jwt.NewParserConfig(0, signingMethod)
 	parser := jwt.NewParser(config)
 	manager := NewJWTManager(parser)
 
@@ -53,7 +53,7 @@ func TestJWTManagerNilContext(t *testing.T) {
 
 func TestJWTManagerNilStast(t *testing.T) {
 	signingMethod := jwt.SigningMethod{Alg: "HS256", Key: "secret"}
-	config := jwt.NewParserConfig(signingMethod)
+	config := jwt.NewParserConfig(0, signingMethod)
 	parser := jwt.NewParser(config)
 	manager := NewJWTManager(parser)
 

--- a/pkg/plugin/oauth2/manager_factory.go
+++ b/pkg/plugin/oauth2/manager_factory.go
@@ -68,7 +68,7 @@ func (f *ManagerFactory) Build(t ManagerType) (Manager, error) {
 			return nil, err
 		}
 
-		return NewJWTManager(jwt.NewParser(jwt.NewParserConfig(signingMethods...))), nil
+		return NewJWTManager(jwt.NewParser(jwt.NewParserConfig(f.oAuthServer.TokenStrategy.Leeway, signingMethods...))), nil
 	case Introspection:
 		settings, err := f.oAuthServer.TokenStrategy.GetIntrospectionSettings()
 		if nil != err {

--- a/pkg/plugin/oauth2/middleware_access_rules_test.go
+++ b/pkg/plugin/oauth2/middleware_access_rules_test.go
@@ -22,7 +22,7 @@ func TestBlockJWTByCountry(t *testing.T) {
 		{Predicate: "country == 'de'", Action: "deny"},
 	}
 
-	parser := jwt.NewParser(jwt.NewParserConfig(jwt.SigningMethod{Alg: signingAlg, Key: secret}))
+	parser := jwt.NewParser(jwt.NewParserConfig(0, jwt.SigningMethod{Alg: signingAlg, Key: secret}))
 
 	mw := NewRevokeRulesMiddleware(parser, revokeRules)
 	token, err := generateToken(signingAlg, secret)
@@ -48,7 +48,7 @@ func TestBlockJWTByUsername(t *testing.T) {
 		{Predicate: "username == 'test@hellofresh.com'", Action: "deny"},
 	}
 
-	parser := jwt.NewParser(jwt.NewParserConfig(jwt.SigningMethod{Alg: signingAlg, Key: secret}))
+	parser := jwt.NewParser(jwt.NewParserConfig(0, jwt.SigningMethod{Alg: signingAlg, Key: secret}))
 
 	mw := NewRevokeRulesMiddleware(parser, revokeRules)
 	token, err := generateToken(signingAlg, secret)
@@ -74,7 +74,7 @@ func TestBlockJWTByIssueDate(t *testing.T) {
 		{Predicate: fmt.Sprintf("iat < %d", time.Now().Add(1*time.Hour).Unix()), Action: "deny"},
 	}
 
-	parser := jwt.NewParser(jwt.NewParserConfig(jwt.SigningMethod{Alg: signingAlg, Key: secret}))
+	parser := jwt.NewParser(jwt.NewParserConfig(0, jwt.SigningMethod{Alg: signingAlg, Key: secret}))
 
 	mw := NewRevokeRulesMiddleware(parser, revokeRules)
 	token, err := generateToken(signingAlg, secret)
@@ -100,7 +100,7 @@ func TestBlockJWTByCountryAndIssueDate(t *testing.T) {
 		{Predicate: fmt.Sprintf("country == 'de' && iat < %d", time.Now().Add(1*time.Hour).Unix()), Action: "deny"},
 	}
 
-	parser := jwt.NewParser(jwt.NewParserConfig(jwt.SigningMethod{Alg: signingAlg, Key: secret}))
+	parser := jwt.NewParser(jwt.NewParserConfig(0, jwt.SigningMethod{Alg: signingAlg, Key: secret}))
 
 	mw := NewRevokeRulesMiddleware(parser, revokeRules)
 	token, err := generateToken(signingAlg, secret)
@@ -134,7 +134,7 @@ func TestEmptyAccessRules(t *testing.T) {
 
 	revokeRules := []*AccessRule{}
 
-	parser := jwt.NewParser(jwt.NewParserConfig(jwt.SigningMethod{Alg: signingAlg, Key: secret}))
+	parser := jwt.NewParser(jwt.NewParserConfig(0, jwt.SigningMethod{Alg: signingAlg, Key: secret}))
 
 	mw := NewRevokeRulesMiddleware(parser, revokeRules)
 
@@ -153,7 +153,7 @@ func TestWrongJWT(t *testing.T) {
 		{Predicate: fmt.Sprintf("country == 'de' && iat < %d", time.Now().Add(1*time.Hour).Unix()), Action: "deny"},
 	}
 
-	parser := jwt.NewParser(jwt.NewParserConfig(jwt.SigningMethod{Alg: signingAlg, Key: "wrong secret"}))
+	parser := jwt.NewParser(jwt.NewParserConfig(0, jwt.SigningMethod{Alg: signingAlg, Key: "wrong secret"}))
 
 	mw := NewRevokeRulesMiddleware(parser, revokeRules)
 	token, err := generateToken(signingAlg, "secret")
@@ -179,7 +179,7 @@ func TestWrongRule(t *testing.T) {
 		{Predicate: "country == 'wrong'", Action: "deny"},
 	}
 
-	parser := jwt.NewParser(jwt.NewParserConfig(jwt.SigningMethod{Alg: signingAlg, Key: secret}))
+	parser := jwt.NewParser(jwt.NewParserConfig(0, jwt.SigningMethod{Alg: signingAlg, Key: secret}))
 
 	mw := NewRevokeRulesMiddleware(parser, revokeRules)
 	token, err := generateToken(signingAlg, secret)

--- a/pkg/plugin/oauth2/oauth.go
+++ b/pkg/plugin/oauth2/oauth.go
@@ -78,7 +78,7 @@ type IntrospectionSettings struct {
 type TokenStrategy struct {
 	Name     string      `bson:"name" json:"name"`
 	Settings interface{} `bson:"settings" json:"settings"`
-	// TODO: this should become part of the settings, but fot "jwt" strategy we expect array of signing methods
+	// TODO: this should become part of the settings, but for "jwt" strategy we expect array of signing methods
 	// at the moment, so this will be BC-breaking change. In the next major version we need to turn settings
 	// into object/dictionary and make leeway one of the settings.
 	Leeway int64 `bson:"leeway" json:"leeway"`

--- a/pkg/plugin/oauth2/oauth.go
+++ b/pkg/plugin/oauth2/oauth.go
@@ -78,6 +78,10 @@ type IntrospectionSettings struct {
 type TokenStrategy struct {
 	Name     string      `bson:"name" json:"name"`
 	Settings interface{} `bson:"settings" json:"settings"`
+	// TODO: this should become part of the settings, but fot "jwt" strategy we expect array of signing methods
+	// at the moment, so this will be BC-breaking change. In the next major version we need to turn settings
+	// into object/dictionary and make leeway one of the settings.
+	Leeway int64 `bson:"leeway" json:"leeway"`
 }
 
 // GetIntrospectionSettings returns the settings for introspection
@@ -95,6 +99,7 @@ func (t TokenStrategy) GetIntrospectionSettings() (*IntrospectionSettings, error
 func (t TokenStrategy) GetJWTSigningMethods() ([]jwt.SigningMethod, error) {
 	var methods []jwt.SigningMethod
 	err := mapstructure.Decode(t.Settings, &methods)
+	// TODO: remove legacy format support in couple minor releases
 	if err != nil {
 		var legacy struct {
 			Secret string `json:"secret"`

--- a/pkg/plugin/oauth2/setup.go
+++ b/pkg/plugin/oauth2/setup.go
@@ -142,7 +142,7 @@ func setupOAuth2(route *proxy.Route, rawConfig plugin.Config) error {
 	}
 
 	route.AddInbound(NewKeyExistsMiddleware(manager))
-	route.AddInbound(NewRevokeRulesMiddleware(jwt.NewParser(jwt.NewParserConfig(signingMethods...)), oauthServer.AccessRules))
+	route.AddInbound(NewRevokeRulesMiddleware(jwt.NewParser(jwt.NewParserConfig(oauthServer.TokenStrategy.Leeway, signingMethods...)), oauthServer.AccessRules))
 
 	return nil
 }


### PR DESCRIPTION
Leeway helps to solve problems with clock skew on different instances. This PR introduces quick and dirty solution that is loosely based on https://github.com/dgrijalva/jwt-go/issues/131 and that should be replaced with the `github.com/dgrijalva/jwt-go` solution as soon as 4.0 with leeway support will be released https://github.com/dgrijalva/jwt-go/pull/248.