### PR TITLE
PTII-374 Build binary in a docker with version (CI will provide one)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.10-alpine AS builder
 
-ARG JANUS_VERSION='0.0.1-docker'
+ARG VERSION='0.0.1-docker'
 
 WORKDIR /go/src/github.com/hellofresh/janus
 
@@ -8,7 +8,7 @@ COPY . .
 
 RUN apk add --update bash make git
 RUN export JANUS_BUILD_ONLY_DEFAULT=1 && \
-    export VERSION=$JANUS_VERSION && \
+    export VERSION=$VERSION && \
     make
 
 # ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 FROM golang:1.10-alpine AS builder
 
+ARG JANUS_VERSION='0.0.1-docker'
+
 WORKDIR /go/src/github.com/hellofresh/janus
 
 COPY . .
 
 RUN apk add --update bash make git
-RUN export JANUS_BUILD_ONLY_DEFAULT=1 && make
+RUN export JANUS_BUILD_ONLY_DEFAULT=1 && \
+    export VERSION=$JANUS_VERSION && \
+    make
 
 # ---
 

--- a/cmd/janus/version.go
+++ b/cmd/janus/version.go
@@ -15,7 +15,7 @@ func NewVersionCmd() *cobra.Command {
 		Short:   "Print the version information",
 		Aliases: []string{"v"},
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("janus %s", version)
+			fmt.Printf("janus %s\n", version)
 		},
 	}
 }


### PR DESCRIPTION
Use default version:

```
$ docker build -t janus:version .
...
$ docker run -it janus:version version
janus 0.0.1-docker
```

Provide one:

```
$ docker build -t janus:version --build-arg VERSION='1.2.3-foobar' .
...
$ docker run -it janus:version version
janus 1.2.3-foobar
```