### PR TITLE
Added duration fmt for really quick queries

### DIFF
--- a/pkg/middleware/logger.go
+++ b/pkg/middleware/logger.go
@@ -55,9 +55,12 @@ func (m *Logger) Handler(handler http.Handler) http.Handler {
 		}
 
 		handler.ServeHTTP(response.Wrap(w, hooks), r)
+		requestDuration := time.Now().Sub(start)
 
 		fields["code"] = responseCode
-		fields["duration"] = int(time.Now().Sub(start) / time.Millisecond)
+		fields["duration"] = int(requestDuration / time.Millisecond)
+		fields["duration-fmt"] = requestDuration.String()
+
 		if originalURL.String() != r.URL.String() {
 			fields["upstream-host"] = r.URL.Host
 			fields["upstream-request"] = r.URL.RequestURI()


### PR DESCRIPTION
For very quick queries duration is always 0, because it is in milliseconds. New field displays request duration in human-readable format.

`{"code":200,"duration":0,"duration-fmt":"238.938µs","host":"localhost","level":"info","method":"OPTIONS","msg":"Completed handling request","referer":"","remote-addr":"[::1]:50262","request":"/example","time":"2018-04-05T10:08:37+02:00","user-agent":"curl"}
`