### PR TITLE
Removing upstream url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Fixed oauth rate limit reported on #276
 
+# Removed
+
+- `Upstream_URL` support is removed
+
 # 3.6.0
 
 ## Added

--- a/docs/plugins/rate_limit.md
+++ b/docs/plugins/rate_limit.md
@@ -1,6 +1,6 @@
 # Rate Limiting
 
-Rate limit how many HTTP requests a developer can make in a given period of seconds, minutes, hours, days, months or years. If the API has no authentication layer, the Client IP address will be used, otherwise the Consumer will be used if an authentication plugin has been configured.
+Rate limit how many HTTP requests a developer can make in a given period of seconds, minutes, hours, days, months or years.
 
 ## Configuration
 

--- a/features/API.feature
+++ b/features/API.feature
@@ -551,7 +551,14 @@ Feature: Manage proxies wit API.
                         ],
                         "preserve_host" : false,
                         "strip_path" : false,
-                        "upstream_url" : "https://github.com/login/oauth/authorize"
+                        "upstreams":{
+                            "balancing":"roundrobin",
+                            "targets":[
+                                {
+                                "target":"https://github.com/login/oauth/authorize"
+                                }
+                            ]
+                        }
                     },
                     "token" : {
                         "listen_path" : "/auth/github/token",
@@ -561,7 +568,14 @@ Feature: Manage proxies wit API.
                         ],
                         "preserve_host" : false,
                         "strip_path" : false,
-                        "upstream_url" : "https://github.com/login/oauth/access_token"
+                        "upstreams":{
+                            "balancing":"roundrobin",
+                            "targets":[
+                                {
+                                "target":"https://github.com/login/oauth/access_token"
+                                }
+                            ]
+                        }
                     },
                     "introspect" : {
                         "listen_path" : "/auth/github/introspect",
@@ -570,7 +584,14 @@ Feature: Manage proxies wit API.
                         ],
                         "preserve_host" : false,
                         "strip_path" : false,
-                        "upstream_url" : "https://api.github.com/user"
+                        "upstreams":{
+                            "balancing":"roundrobin",
+                            "targets":[
+                                {
+                                "target":"https://api.github.com/user"
+                                }
+                            ]
+                        }
                     }
                 },
                 "secrets" : {
@@ -625,7 +646,14 @@ Feature: Manage proxies wit API.
                         ],
                         "preserve_host" : false,
                         "strip_path" : false,
-                        "upstream_url" : "https://github.com/login/oauth/authorize"
+                        "upstreams":{
+                            "balancing":"roundrobin",
+                            "targets":[
+                                {
+                                "target":"https://github.com/login/oauth/authorize"
+                                }
+                            ]
+                        }
                     },
                     "token" : {
                         "listen_path" : "/auth/github/token",
@@ -635,7 +663,14 @@ Feature: Manage proxies wit API.
                         ],
                         "preserve_host" : false,
                         "strip_path" : false,
-                        "upstream_url" : "https://github.com/login/oauth/access_token"
+                        "upstreams":{
+                            "balancing":"roundrobin",
+                            "targets":[
+                                {
+                                "target":"https://github.com/login/oauth/access_token"
+                                }
+                            ]
+                        }
                     },
                     "introspect" : {
                         "listen_path" : "/auth/github/introspect",
@@ -644,7 +679,14 @@ Feature: Manage proxies wit API.
                         ],
                         "preserve_host" : false,
                         "strip_path" : false,
-                        "upstream_url" : "https://api.github.com/user"
+                        "upstreams":{
+                            "balancing":"roundrobin",
+                            "targets":[
+                                {
+                                "target":"https://api.github.com/user"
+                                }
+                            ]
+                        }
                     }
                 },
                 "secrets" : {

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hellofresh/janus/pkg/api"
+	"github.com/hellofresh/janus/pkg/proxy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +20,12 @@ func TestSuccessfulValidation(t *testing.T) {
 	instance := api.NewDefinition()
 	instance.Name = "Test"
 	instance.Proxy.ListenPath = "/"
-	instance.Proxy.UpstreamURL = "http://example.com"
+	instance.Proxy.Upstreams = &proxy.Upstreams{
+		Balancing: "roundrobin",
+		Targets: []*proxy.Target{
+			&proxy.Target{Target: "http:/example.com"},
+		},
+	}
 
 	isValid, err := instance.Validate()
 	require.NoError(t, err)

--- a/pkg/api/file_repository_test.go
+++ b/pkg/api/file_repository_test.go
@@ -46,8 +46,13 @@ func TestNewFileSystemRepository(t *testing.T) {
 	defToAdd := &Definition{
 		Name: "foo-bar",
 		Proxy: &proxy.Definition{
-			ListenPath:  "/foo/bar/*",
-			UpstreamURL: "http://example.com/foo/bar/",
+			ListenPath: "/foo/bar/*",
+			Upstreams: &proxy.Upstreams{
+				Balancing: "roundrobin",
+				Targets: []*proxy.Target{
+					&proxy.Target{Target: "http://example.com/foo/bar/"},
+				},
+			},
 		},
 	}
 	err = fsRepo.Add(defToAdd)

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -26,9 +26,14 @@ func TestLoadValidAPIDefinitions(t *testing.T) {
 		Name:   "test1",
 		Active: true,
 		Proxy: &proxy.Definition{
-			ListenPath:  "/test1",
-			UpstreamURL: "http://test1",
-			Methods:     []string{http.MethodGet},
+			ListenPath: "/test1",
+			Upstreams: &proxy.Upstreams{
+				Balancing: "roundrobin",
+				Targets: []*proxy.Target{
+					&proxy.Target{Target: "http://test1"},
+				},
+			},
+			Methods: []string{http.MethodGet},
 		},
 		Plugins: []api.Plugin{
 			{
@@ -50,9 +55,14 @@ func TestLoadValidAPIDefinitions(t *testing.T) {
 		Name:   "test2",
 		Active: true,
 		Proxy: &proxy.Definition{
-			ListenPath:  "/test2",
-			UpstreamURL: "http://test2",
-			Methods:     []string{http.MethodGet},
+			ListenPath: "/test2",
+			Upstreams: &proxy.Upstreams{
+				Balancing: "roundrobin",
+				Targets: []*proxy.Target{
+					&proxy.Target{Target: "http://test2"},
+				},
+			},
+			Methods: []string{http.MethodGet},
 		},
 	})
 
@@ -69,9 +79,14 @@ func TestLoadInvalidAPIDefinitions(t *testing.T) {
 		Name:   "test2",
 		Active: true,
 		Proxy: &proxy.Definition{
-			ListenPath:  "/test2",
-			UpstreamURL: "http://test2",
-			Methods:     []string{http.MethodGet},
+			ListenPath: "/test2",
+			Upstreams: &proxy.Upstreams{
+				Balancing: "roundrobin",
+				Targets: []*proxy.Target{
+					&proxy.Target{Target: "http://test2"},
+				},
+			},
+			Methods: []string{http.MethodGet},
 		},
 	}
 	err := apiRepo.Add(definition)
@@ -91,8 +106,13 @@ func TestLoadAPIDefinitionsMissingHTTPMethods(t *testing.T) {
 		Name:   "test1",
 		Active: true,
 		Proxy: &proxy.Definition{
-			ListenPath:  "/test1",
-			UpstreamURL: "http://test1",
+			ListenPath: "/test1",
+			Upstreams: &proxy.Upstreams{
+				Balancing: "roundrobin",
+				Targets: []*proxy.Target{
+					&proxy.Target{Target: "http://test1"},
+				},
+			},
 		},
 	})
 
@@ -109,8 +129,13 @@ func TestLoadInactiveAPIDefinitions(t *testing.T) {
 		Name:   "test1",
 		Active: false,
 		Proxy: &proxy.Definition{
-			ListenPath:  "/test1",
-			UpstreamURL: "http://test1",
+			ListenPath: "/test1",
+			Upstreams: &proxy.Upstreams{
+				Balancing: "roundrobin",
+				Targets: []*proxy.Target{
+					&proxy.Target{Target: "http://test1"},
+				},
+			},
 		},
 	})
 

--- a/pkg/plugin/oauth2/file_repository.go
+++ b/pkg/plugin/oauth2/file_repository.go
@@ -47,7 +47,7 @@ func NewFileSystemRepository(dir string) (*FileSystemRepository, error) {
 }
 
 func (r *FileSystemRepository) parseOAuthServer(oauthServerRaw []byte) *OAuth {
-	oauthServer := new(OAuth)
+	oauthServer := NewOAuth()
 	if err := json.Unmarshal(oauthServerRaw, oauthServer); err != nil {
 		log.WithError(err).Error("[RPC] --> Couldn't unmarshal oauth server configuration")
 	}

--- a/pkg/plugin/oauth2/handlers.go
+++ b/pkg/plugin/oauth2/handlers.go
@@ -98,16 +98,15 @@ func (c *Controller) PutBy() http.HandlerFunc {
 // Post is the create handler
 func (c *Controller) Post() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var oauth OAuth
-
-		err := json.NewDecoder(r.Body).Decode(&oauth)
+		oauth := NewOAuth()
+		err := json.NewDecoder(r.Body).Decode(oauth)
 		if nil != err {
 			errors.Handler(w, err)
 			return
 		}
 
 		span := opentracing.FromContext(r.Context(), "datastore.Add")
-		err = c.repo.Add(&oauth)
+		err = c.repo.Add(oauth)
 		c.dispatch(notifier.NoticeOAuthServerAdded)
 		span.Finish()
 

--- a/pkg/plugin/oauth2/in_memory_repository.go
+++ b/pkg/plugin/oauth2/in_memory_repository.go
@@ -1,7 +1,6 @@
 package oauth2
 
 import (
-	"net/url"
 	"sync"
 )
 
@@ -35,20 +34,6 @@ func (r *InMemoryRepository) FindByName(name string) (*OAuth, error) {
 	defer r.RUnlock()
 
 	return r.findByName(name)
-}
-
-// FindByTokenURL returns OAuth Server records with corresponding token url
-func (r *InMemoryRepository) FindByTokenURL(url url.URL) (*OAuth, error) {
-	r.RLock()
-	defer r.RUnlock()
-
-	for _, server := range r.servers {
-		if server.Endpoints.Token.UpstreamURL == url.String() {
-			return server, nil
-		}
-	}
-
-	return nil, ErrOauthServerNotFound
 }
 
 // Add add a new OAuth Server to the repository

--- a/pkg/plugin/oauth2/in_memory_repository_test.go
+++ b/pkg/plugin/oauth2/in_memory_repository_test.go
@@ -1,7 +1,6 @@
 package oauth2
 
 import (
-	"net/url"
 	"testing"
 
 	"github.com/hellofresh/janus/pkg/proxy"
@@ -26,14 +25,6 @@ func TestOauthServerInMemoryRepository(t *testing.T) {
 		{
 			scenario: "find all oauth servers",
 			function: testFindAllOAuthServers,
-		},
-		{
-			scenario: "find by token url",
-			function: testFindByTokenURL,
-		},
-		{
-			scenario: "not find by token url",
-			function: testNotFindByTokenURL,
 		},
 		{
 			scenario: "find by name",
@@ -69,24 +60,6 @@ func testFindAllOAuthServers(t *testing.T, repo Repository) {
 	assert.Len(t, results, 2)
 }
 
-func testFindByTokenURL(t *testing.T, repo Repository) {
-	tokenURL, err := url.Parse("http://test.com/token")
-	assert.NoError(t, err)
-
-	server, err := repo.FindByTokenURL(*tokenURL)
-	assert.NoError(t, err)
-	assert.NotNil(t, server)
-}
-
-func testNotFindByTokenURL(t *testing.T, repo Repository) {
-	tokenURL, err := url.Parse("http://test.com/wrong")
-	assert.NoError(t, err)
-
-	server, err := repo.FindByTokenURL(*tokenURL)
-	assert.Error(t, err)
-	assert.Nil(t, server)
-}
-
 func testFindByName(t *testing.T, repo Repository) {
 	definition, err := repo.FindByName("test1")
 	assert.NoError(t, err)
@@ -105,8 +78,13 @@ func newInMemoryRepo() *InMemoryRepository {
 		Name: "test1",
 		Endpoints: Endpoints{
 			Token: &proxy.Definition{
-				ListenPath:  "/token",
-				UpstreamURL: "http://test.com/token",
+				ListenPath: "/token",
+				Upstreams: &proxy.Upstreams{
+					Balancing: "roundrobin",
+					Targets: []*proxy.Target{
+						&proxy.Target{Target: "http://test.com/token"},
+					},
+				},
 			},
 		},
 	})
@@ -115,8 +93,13 @@ func newInMemoryRepo() *InMemoryRepository {
 		Name: "test2",
 		Endpoints: Endpoints{
 			Token: &proxy.Definition{
-				ListenPath:  "/token",
-				UpstreamURL: "http://test2.com/token",
+				ListenPath: "/token",
+				Upstreams: &proxy.Upstreams{
+					Balancing: "roundrobin",
+					Targets: []*proxy.Target{
+						&proxy.Target{Target: "http://test2.com/token"},
+					},
+				},
 			},
 		},
 	})

--- a/pkg/plugin/oauth2/manager_factory.go
+++ b/pkg/plugin/oauth2/manager_factory.go
@@ -82,7 +82,7 @@ func (f *ManagerFactory) Build(t ManagerType) (Manager, error) {
 			return nil, err
 		}
 
-		manager, err := NewIntrospectionManager(f.oAuthServer.Endpoints.Introspect.UpstreamURL, settings)
+		manager, err := NewIntrospectionManager(f.oAuthServer.Endpoints.Introspect, settings)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/plugin/oauth2/oauth.go
+++ b/pkg/plugin/oauth2/oauth.go
@@ -84,6 +84,19 @@ type TokenStrategy struct {
 	Leeway int64 `bson:"leeway" json:"leeway"`
 }
 
+// NewOAuth creates a new instance of OAuth
+func NewOAuth() *OAuth {
+	return &OAuth{
+		Secrets: make(map[string]string),
+		Endpoints: Endpoints{
+			Authorize:  proxy.NewDefinition(),
+			Introspect: proxy.NewDefinition(),
+			Revoke:     proxy.NewDefinition(),
+			Token:      proxy.NewDefinition(),
+		},
+	}
+}
+
 // GetIntrospectionSettings returns the settings for introspection
 func (t TokenStrategy) GetIntrospectionSettings() (*IntrospectionSettings, error) {
 	var settings *IntrospectionSettings

--- a/pkg/proxy/definition.go
+++ b/pkg/proxy/definition.go
@@ -10,10 +10,8 @@ import (
 
 // Definition defines proxy rules for a route
 type Definition struct {
-	PreserveHost bool   `bson:"preserve_host" json:"preserve_host" mapstructure:"preserve_host"`
-	ListenPath   string `bson:"listen_path" json:"listen_path" mapstructure:"listen_path" valid:"required~proxy.listen_path is required,urlpath"`
-	// Deprecated: Use Upstreams instead.
-	UpstreamURL         string     `bson:"upstream_url" json:"upstream_url" valid:"url"`
+	PreserveHost        bool       `bson:"preserve_host" json:"preserve_host" mapstructure:"preserve_host"`
+	ListenPath          string     `bson:"listen_path" json:"listen_path" mapstructure:"listen_path" valid:"required~proxy.listen_path is required,urlpath"`
 	Upstreams           *Upstreams `bson:"upstreams" json:"upstreams" mapstructure:"upstreams"`
 	InsecureSkipVerify  bool       `bson:"insecure_skip_verify" json:"insecure_skip_verify" mapstructure:"insecure_skip_verify"`
 	StripPath           bool       `bson:"strip_path" json:"strip_path" mapstructure:"strip_path"`

--- a/pkg/proxy/definition_test.go
+++ b/pkg/proxy/definition_test.go
@@ -57,8 +57,13 @@ func testNewDefinitions(t *testing.T) {
 
 func testSuccessfulValidation(t *testing.T) {
 	definition := Definition{
-		ListenPath:  "/*",
-		UpstreamURL: "http://test.com",
+		ListenPath: "/*",
+		Upstreams: &Upstreams{
+			Balancing: "roundrobin",
+			Targets: []*Target{
+				&Target{Target: "http://test.com"},
+			},
+		},
 	}
 	isValid, err := definition.Validate()
 
@@ -76,8 +81,13 @@ func testEmptyListenPathValidation(t *testing.T) {
 
 func testInvalidTargetURLValidation(t *testing.T) {
 	definition := Definition{
-		ListenPath:  " ",
-		UpstreamURL: "wrong",
+		ListenPath: " ",
+		Upstreams: &Upstreams{
+			Balancing: "roundrobin",
+			Targets: []*Target{
+				&Target{Target: "wrong"},
+			},
+		},
 	}
 	isValid, err := definition.Validate()
 
@@ -100,7 +110,6 @@ func testRouteToJSON(t *testing.T) {
 			],
 			"preserve_host":false,
 			"listen_path":"",
-			"upstream_url":"",
 			"strip_path":false,
 			"upstreams":{
 				"balancing":"",
@@ -130,7 +139,6 @@ func testJSONToRoute(t *testing.T) {
 			"hosts":[],
 			"preserve_host":false,
 			"listen_path":"",
-			"upstream_url":"/*",
 			"strip_path":false
 		}
 	}`))

--- a/pkg/proxy/register_test.go
+++ b/pkg/proxy/register_test.go
@@ -104,11 +104,14 @@ func createProxyDefinitions() []*Definition {
 			Methods: []string{"ALL"},
 		},
 		{
-			ListenPath:  "/append/*",
-			UpstreamURL: "http://localhost:9089/hello-world",
-			AppendPath:  true,
-			Upstreams:   &Upstreams{},
-			Methods:     []string{"GET"},
+			ListenPath: "/append/*",
+			Upstreams: &Upstreams{
+				Balancing: "roundrobin",
+				Targets:   []*Target{{Target: "http://localhost:9089/hello-world"}},
+			},
+			AppendPath: true,
+			Upstreams:  &Upstreams{},
+			Methods:    []string{"GET"},
 		},
 		{
 			ListenPath: "/api/recipes/{id:[\\da-f]{24}}",

--- a/pkg/proxy/register_test.go
+++ b/pkg/proxy/register_test.go
@@ -110,7 +110,6 @@ func createProxyDefinitions() []*Definition {
 				Targets:   []*Target{{Target: "http://localhost:9089/hello-world"}},
 			},
 			AppendPath: true,
-			Upstreams:  &Upstreams{},
 			Methods:    []string{"GET"},
 		},
 		{


### PR DESCRIPTION
## What does this PR do?
Removes all dependencies on the UpstreamURL that was deprecated on 3.5.0
