### PR TITLE
Fix markup so it will looks like a table

### DIFF
--- a/docs/plugins/cb.md
+++ b/docs/plugins/cb.md
@@ -23,7 +23,8 @@ The plain cb config:
 }
 ```
 
-| Configuration | Description |
+Configuration | Description
+:---|:---|
 | timeout                     | Timeout that the CB will wait till the request responds |
 | max_concurrent_requests     | How many commands of the same type can run at the same time |
 | error_percent_threshold     | Causes circuits to open once the rolling measure of errors exceeds this percent of requests |


### PR DESCRIPTION
## What does this PR do?

This **PR** fixes the markup, so instead of this:

![image](https://user-images.githubusercontent.com/8372070/39195886-12040496-47e1-11e8-853c-83e37c5606c6.png)

it will look like this:

![image](https://user-images.githubusercontent.com/8372070/39195970-46285858-47e1-11e8-8f1c-b0145f61bd0a.png)

