### PR TITLE
Configurable Session Timeout

### DIFF
--- a/janus.sample.toml
+++ b/janus.sample.toml
@@ -112,6 +112,8 @@
     algorithm = "HS256"
     # This is the secret that you will use to encrypt your JWT
     secret = "secret key"
+    # This is the duration before the issued administration token expires
+    # timeout = "1h"
 
     # [web.credentials.github]
     # organizations = ["yourOrganization"]

--- a/pkg/config/specification.go
+++ b/pkg/config/specification.go
@@ -79,9 +79,10 @@ type Stats struct {
 type Credentials struct {
 	// Algorithm defines admin JWT signing algorithm.
 	// Currently the following algorithms are supported: HS256, HS384, HS512.
-	Algorithm      string `envconfig:"ALGORITHM"`
-	Secret         string `envconfig:"SECRET"`
-	JanusAdminTeam string `envconfig:"JANUS_ADMIN_TEAM"`
+	Algorithm      string        `envconfig:"ALGORITHM"`
+	Secret         string        `envconfig:"SECRET"`
+	JanusAdminTeam string        `envconfig:"JANUS_ADMIN_TEAM"`
+	Timeout        time.Duration `envconfig:"TOKEN_TIMEOUT"`
 	Github         Github
 	Basic          Basic
 }
@@ -147,6 +148,7 @@ func init() {
 	viper.SetDefault("web.tls.port", "8444")
 	viper.SetDefault("web.tls.redirect", true)
 	viper.SetDefault("web.credentials.algorithm", "HS256")
+	viper.SetDefault("web.credentials.timeout", time.Hour)
 	viper.SetDefault("web.credentials.basic.users", map[string]string{"admin": "admin"})
 	viper.SetDefault("web.credentials.github.teams", make(map[string]string))
 

--- a/pkg/config/specification_test.go
+++ b/pkg/config/specification_test.go
@@ -16,6 +16,7 @@ func Test_LoadEnv(t *testing.T) {
 	os.Setenv("GITHUB_ORGANIZATIONS", "hellofresh,tests")
 	os.Setenv("GITHUB_TEAMS", "hellofresh:tests,tests:devs")
 	os.Setenv("JANUS_ADMIN_TEAM", "janus-owners")
+	os.Setenv("TOKEN_TIMEOUT", "2h")
 
 	globalConfig, err := LoadEnv()
 	require.NoError(t, err)
@@ -31,6 +32,7 @@ func Test_LoadEnv(t *testing.T) {
 	assert.Equal(t, map[string]string{"hellofresh": "tests", "tests": "devs"}, globalConfig.Web.Credentials.Github.Teams)
 	assert.Equal(t, []string{"hellofresh", "tests"}, globalConfig.Web.Credentials.Github.Organizations)
 	assert.Equal(t, "janus-owners", globalConfig.Web.Credentials.JanusAdminTeam)
+	assert.Equal(t, 2*time.Hour, globalConfig.Web.Credentials.Timeout)
 	assert.True(t, globalConfig.Web.Credentials.Github.IsConfigured())
 
 }

--- a/pkg/jwt/guard.go
+++ b/pkg/jwt/guard.go
@@ -31,7 +31,7 @@ func NewGuard(cred config.Credentials) Guard {
 			TokenLookup:    "header:Authorization",
 		},
 		SigningMethod: SigningMethod{Alg: cred.Algorithm, Key: cred.Secret},
-		Timeout:       time.Hour,
+		Timeout:       cred.Timeout,
 		MaxRefresh:    time.Hour * 24,
 	}
 }


### PR DESCRIPTION
## What does this PR do?
Allow administration token timeout to be configurable via envconfig (`TOKEN_TIMEOUT`)
The default value remains to be 1 hour.

## Related
https://github.com/hellofresh/janus-dashboard/issues/293