### PR TITLE
Use stable go version in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - docker
 
 go:
-  - 1.x
+  - stable
 
 env:
   - MAKE_TASK=test


### PR DESCRIPTION
## What does this PR do?
Updates `travis.yml` to run tests with stable version.
