### PR TITLE
PT-1479 Fixed server initialisation race condition

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -212,8 +212,8 @@
     "state",
     "timer"
   ]
-  revision = "5ea5b6bcbabc419be4796756b9ae00a7b1f0d36a"
-  version = "0.7.0"
+  revision = "2217eefe1ccbabac7dc9d6e040c8fd2b79dd022f"
+  version = "v0.8.0"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -531,6 +531,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d86b50911a00b11aac39b88fb4d013fc2b810abe1fbe13f7f2faf1a3bfc8e852"
+  inputs-digest = "81fbd04ddffa630850d41d76167aa2829d4fc456ad606ca62bbe2b8b04dba259"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -62,7 +62,7 @@
 
 [[constraint]]
   name = "github.com/hellofresh/stats-go"
-  version = "0.7.0"
+  version = "0.8.0"
 
 [[constraint]]
   name = "github.com/kelseyhightower/envconfig"

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ deps:
 	@go get -u github.com/golang/dep/cmd/dep
 	@go get -u github.com/golang/lint/golint
 	@go get -u github.com/DATA-DOG/godog/cmd/godog
-	@dep ensure -vendor-only
+	@dep ensure -v -vendor-only
 
 build:
 	@echo "$(OK_COLOR)==> Building... $(NO_COLOR)"

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -38,7 +38,7 @@ func initLog() {
 	}
 }
 
-func initStatsd() {
+func initStatsClient() {
 	// FIXME: this causes application hang because we're in the locked log already
 	//statsLog.SetHandler(func(msg string, fields map[string]interface{}, err error) {
 	//	entry := log.WithFields(log.Fields(fields))
@@ -61,7 +61,7 @@ func initStatsd() {
 
 	statsClient, err = stats.NewClient(globalConfig.Stats.DSN)
 	if err != nil {
-		log.WithError(err).Fatal("Error initializing statsd client")
+		log.WithError(err).Fatal("Error initializing stats client")
 	}
 
 	statsClient.SetHTTPMetricCallback(bucket.NewHasIDAtSecondLevelCallback(&bucket.SecondLevelIDConfig{

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -57,7 +57,7 @@ func RunServerStart(ctx context.Context, opts *ServerStartOptions) error {
 
 	initConfig()
 	initLog()
-	initStatsd()
+	initStatsClient()
 
 	tracingFactory := opentracing.New(globalConfig.Tracing)
 	tracingFactory.Setup()

--- a/pkg/api/repository.go
+++ b/pkg/api/repository.go
@@ -47,7 +47,7 @@ func BuildRepository(dsn string, refreshTime time.Duration) (Repository, error) 
 		log.Debug("File system based configuration chosen")
 		apiPath := fmt.Sprintf("%s/apis", dsnURL.Path)
 
-		log.WithField("api_path", apiPath).Debug("Trying to load configuration files")
+		log.WithField("path", apiPath).Debug("Trying to load API configuration files")
 		repo, err := NewFileSystemRepository(apiPath)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not create a file system repository")

--- a/pkg/loader/api_loader_test.go
+++ b/pkg/loader/api_loader_test.go
@@ -72,7 +72,7 @@ func createRegisterAndRouter() (router.Router, error) {
 	r := createRouter()
 	r.Use(middleware.NewRecovery(errors.RecoveryHandler))
 
-	register := proxy.NewRegister(proxy.WithRouter(r), proxy.WithStatsClient(client.NewNoop(false)))
+	register := proxy.NewRegister(proxy.WithRouter(r), proxy.WithStatsClient(client.NewNoop()))
 	proxyRepo, err := api.NewFileSystemRepository("../../assets/apis")
 	if err != nil {
 		return nil, err

--- a/pkg/plugin/cb/stats_collector_test.go
+++ b/pkg/plugin/cb/stats_collector_test.go
@@ -37,7 +37,7 @@ func TestCollector(t *testing.T) {
 }
 
 func testCollectorCreated(t *testing.T) {
-	metricsClient := client.NewNoop(false)
+	metricsClient := client.NewNoop()
 	_, err := NewStatsCollector("test", metricsClient)
 
 	require.NoError(t, err)
@@ -50,7 +50,7 @@ func testCollectorNotCreated(t *testing.T) {
 }
 
 func testCollectorRegistry(t *testing.T) {
-	c := NewCollectorRegistry(client.NewNoop(false))
+	c := NewCollectorRegistry(client.NewNoop())
 	require.NotNil(t, c)
 
 	c = NewCollectorRegistry(nil)

--- a/pkg/plugin/oauth2/file_repository.go
+++ b/pkg/plugin/oauth2/file_repository.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"path/filepath"
-	"strings"
 	"sync"
 
 	log "github.com/sirupsen/logrus"
@@ -27,7 +26,7 @@ func NewFileSystemRepository(dir string) (*FileSystemRepository, error) {
 	}
 
 	for _, f := range files {
-		if strings.Contains(f.Name(), ".json") {
+		if filepath.Ext(f.Name()) == ".json" {
 			filePath := filepath.Join(dir, f.Name())
 			oauthServerRaw, err := ioutil.ReadFile(filePath)
 			if err != nil {

--- a/pkg/plugin/oauth2/loader.go
+++ b/pkg/plugin/oauth2/loader.go
@@ -108,7 +108,7 @@ func (m *OAuthLoader) getManager(oauthServer *OAuth) (Manager, error) {
 
 func (m *OAuthLoader) registerRoutes(endpoints map[*proxy.RouterDefinition][]router.Constructor) {
 	for endpoint, middleware := range endpoints {
-		if endpoint.Definition == nil {
+		if endpoint.Definition == nil || endpoint.Definition.ListenPath == "" {
 			log.Debug("Endpoint not registered")
 			continue
 		}

--- a/pkg/plugin/oauth2/setup.go
+++ b/pkg/plugin/oauth2/setup.go
@@ -94,7 +94,7 @@ func onStartup(event interface{}) error {
 		}
 	case file:
 		authPath := fmt.Sprintf("%s/auth", dsnURL.Path)
-		log.WithField("auth_path", authPath).Debug("Trying to load configuration files")
+		log.WithField("path", authPath).Debug("Trying to load Auth configuration files")
 
 		repo, err = NewFileSystemRepository(authPath)
 		if err != nil {

--- a/pkg/proxy/register_test.go
+++ b/pkg/proxy/register_test.go
@@ -138,7 +138,7 @@ func createRegisterAndRouter() router.Router {
 }
 
 func createRegister(r router.Router) *Register {
-	register := NewRegister(WithRouter(r), WithStatsClient(client.NewNoop(false)))
+	register := NewRegister(WithRouter(r), WithStatsClient(client.NewNoop()))
 
 	definitions := createProxyDefinitions()
 	for _, def := range definitions {


### PR DESCRIPTION
## What does this PR do?
When loading proxy definitions from filesystem proxy register may be uninitialised in some cases because of race condition. I extracted proxy register initialisation outside of go-routine to avoid the possibbility of it.

Fixes https://github.com/hellofresh/janus/issues/338