### PR TITLE
Get the empty list in the output when definitions list is empty

### DIFF
--- a/features/API.feature
+++ b/features/API.feature
@@ -14,6 +14,12 @@ Feature: Manage proxies wit API.
         When I request "/apis" API path with "GET" method
         Then I should receive 401 response code
 
+    Scenario: API list must return empty list when no endpoints set
+        Given request JWT token is valid admin token
+        When I request "/apis" API path with "GET" method
+        Then I should receive 200 response code
+        And response JSON body is an array of length 0
+
     Scenario: API should be created with defaults
         Given request JWT token is valid admin token
         And request JSON payload:

--- a/pkg/web/api_handler.go
+++ b/pkg/web/api_handler.go
@@ -31,6 +31,12 @@ func (c *APIHandler) Get() http.HandlerFunc {
 		span := opentracing.FromContext(r.Context(), "definitions.GetAll")
 		defer span.Finish()
 
+		if c.Cfgs.Definitions == nil {
+			// id definitions list is empty - fake it with simple slice to get the empty JSON array in the output
+			render.JSON(w, http.StatusOK, []int{})
+			return
+		}
+
 		render.JSON(w, http.StatusOK, c.Cfgs.Definitions)
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Definitions list request returns `null` in teh output when the list is empty. This PR fixes the output to return empty array in the JSON output for better API consistency.

Based on https://github.com/hellofresh/janus/issues/335 investigation