### PR TITLE
Support b3 http propagation format for jaeger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Added
+- Support b3 http propagation format for jaeger
+
 ## Fixed
 - Race condition on application start. Reported on #348
 

--- a/docs/misc/tracing.md
+++ b/docs/misc/tracing.md
@@ -81,6 +81,11 @@ You can define that you want to use Jaeger on your configuration file under the 
     #
     # QueueSize = 0
 
+    # PropagationFormat is the propagation format jaeger will use.
+    # Leave it blank to use jaeger default propagation mechanism
+    # 
+    # PropagationFormat = "zipkin"
+
 ```
 
 ### Google Cloud Platform - Tracing

--- a/pkg/config/specification.go
+++ b/pkg/config/specification.go
@@ -120,6 +120,7 @@ type JaegerTracing struct {
 	BufferFlushInterval time.Duration `envconfig:"TRACING_JAEGER_BUFFER_FLUSH_INTERVAL"`
 	LogSpans            bool          `envconfig:"TRACING_JAEGER_LOG_SPANS"`
 	QueueSize           int           `envconfig:"TRACING_JAEGER_QUEUE_SIZE"`
+	PropagationFormat   string        `envconfig:"TRACING_JAEGER_PROPAGATION_FORMAT"`
 }
 
 // Tracing represents the distributed tracing configuration

--- a/pkg/opentracing/opentracing.go
+++ b/pkg/opentracing/opentracing.go
@@ -9,7 +9,9 @@ import (
 	"github.com/hellofresh/janus/pkg/config"
 	"github.com/opentracing/opentracing-go"
 	log "github.com/sirupsen/logrus"
+	jaeger "github.com/uber/jaeger-client-go"
 	jaegercfg "github.com/uber/jaeger-client-go/config"
+	"github.com/uber/jaeger-client-go/zipkin"
 	"github.com/uber/jaeger-lib/metrics"
 )
 
@@ -95,11 +97,43 @@ func (t *Tracing) buildJaeger(componentName string, c config.JaegerTracing) (ope
 		},
 	}
 
-	return cfg.New(
-		componentName,
-		jaegercfg.Logger(jaegerLoggerAdapter{log.StandardLogger()}),
-		jaegercfg.Metrics(metrics.NullFactory),
+	tracerMetrics := jaeger.NewMetrics(metrics.NullFactory, nil)
+	tracerLogger := jaegerLoggerAdapter{log.StandardLogger()}
+	sampler, err := cfg.Sampler.NewSampler(componentName, tracerMetrics)
+	if err != nil {
+		log.WithError(err).Error("failed to create jaeger sampler")
+	}
+
+	reporter, err := cfg.Reporter.NewReporter(componentName, tracerMetrics, tracerLogger)
+	if err != nil {
+		log.WithError(err).Error("failed to create jaeger reporter")
+	}
+
+	var (
+		tracer opentracing.Tracer
+		closer io.Closer
 	)
+
+	switch c.PropagationFormat {
+	case "zipkin":
+		log.Debug("Using zipkin b3 http propagation format")
+		zipkinPropagator := zipkin.NewZipkinB3HTTPHeaderPropagator()
+		tracer, closer = jaeger.NewTracer(componentName, sampler, reporter,
+			jaeger.TracerOptions.Metrics(tracerMetrics),
+			jaeger.TracerOptions.Logger(tracerLogger),
+			jaeger.TracerOptions.Injector(opentracing.HTTPHeaders, zipkinPropagator),
+			jaeger.TracerOptions.Extractor(opentracing.HTTPHeaders, zipkinPropagator),
+			jaeger.TracerOptions.ZipkinSharedRPCSpan(true),
+		)
+	default:
+		log.Debug("Using jaeger propagation format")
+		tracer, closer = jaeger.NewTracer(componentName, sampler, reporter,
+			jaeger.TracerOptions.Metrics(tracerMetrics),
+			jaeger.TracerOptions.Logger(tracerLogger),
+		)
+	}
+
+	return tracer, closer, nil
 }
 
 // FromContext creates a span from a context that contains a parent span

--- a/pkg/opentracing/opentracing.go
+++ b/pkg/opentracing/opentracing.go
@@ -11,13 +11,13 @@ import (
 	log "github.com/sirupsen/logrus"
 	jaeger "github.com/uber/jaeger-client-go"
 	jaegercfg "github.com/uber/jaeger-client-go/config"
-	"github.com/uber/jaeger-client-go/zipkin"
 	"github.com/uber/jaeger-lib/metrics"
 )
 
 const (
 	gcloudTracing = "googleCloud"
 	jaegerTracing = "jaeger"
+	zipkin        = "zipkin"
 )
 
 // Tracing is the tracing functionality
@@ -115,7 +115,7 @@ func (t *Tracing) buildJaeger(componentName string, c config.JaegerTracing) (ope
 	)
 
 	switch c.PropagationFormat {
-	case "zipkin":
+	case zipkin:
 		log.Debug("Using zipkin b3 http propagation format")
 		zipkinPropagator := zipkin.NewZipkinB3HTTPHeaderPropagator()
 		tracer, closer = jaeger.NewTracer(componentName, sampler, reporter,

--- a/pkg/opentracing/opentracing.go
+++ b/pkg/opentracing/opentracing.go
@@ -11,13 +11,14 @@ import (
 	log "github.com/sirupsen/logrus"
 	jaeger "github.com/uber/jaeger-client-go"
 	jaegercfg "github.com/uber/jaeger-client-go/config"
+	"github.com/uber/jaeger-client-go/zipkin"
 	"github.com/uber/jaeger-lib/metrics"
 )
 
 const (
-	gcloudTracing = "googleCloud"
-	jaegerTracing = "jaeger"
-	zipkin        = "zipkin"
+	gcloudTracing     = "googleCloud"
+	jaegerTracing     = "jaeger"
+	zipkinPropagation = "zipkin"
 )
 
 // Tracing is the tracing functionality
@@ -115,7 +116,7 @@ func (t *Tracing) buildJaeger(componentName string, c config.JaegerTracing) (ope
 	)
 
 	switch c.PropagationFormat {
-	case zipkin:
+	case zipkinPropagation:
 		log.Debug("Using zipkin b3 http propagation format")
 		zipkinPropagator := zipkin.NewZipkinB3HTTPHeaderPropagator()
 		tracer, closer = jaeger.NewTracer(componentName, sampler, reporter,

--- a/pkg/opentracing/opentracing.go
+++ b/pkg/opentracing/opentracing.go
@@ -101,12 +101,12 @@ func (t *Tracing) buildJaeger(componentName string, c config.JaegerTracing) (ope
 	tracerLogger := jaegerLoggerAdapter{log.StandardLogger()}
 	sampler, err := cfg.Sampler.NewSampler(componentName, tracerMetrics)
 	if err != nil {
-		log.WithError(err).Error("failed to create jaeger sampler")
+		return nil, nil, err
 	}
 
 	reporter, err := cfg.Reporter.NewReporter(componentName, tracerMetrics, tracerLogger)
 	if err != nil {
-		log.WithError(err).Error("failed to create jaeger reporter")
+		return nil, nil, err
 	}
 
 	var (


### PR DESCRIPTION
Support zipkin b3 http propagation format for jaeger. Defaults to jaeger propagation mechanism if format is not defined.

closes https://github.com/hellofresh/janus/issues/354