### PR TITLE
PT-2147 Fixed configuration listener that made API stuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Unreleased
 
+# 3.8.4
+
+## Fixed
+- Fixed configuration listener that made API stuck
+
+# 3.8.3
+
 ## Added
 - Support b3 http propagation format for jaeger
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ all: clean deps test build
 deps:
 	@echo "$(OK_COLOR)==> Installing dependencies$(NO_COLOR)"
 	@go get -u github.com/golang/dep/cmd/dep
-	@go get -u github.com/golang/lint/golint
+	@go get -u golang.org/x/lint/golint
 	@go get -u github.com/DATA-DOG/godog/cmd/godog
 	@dep ensure -v -vendor-only
 


### PR DESCRIPTION
## What does this PR do?

Now server is listening to the configuration changes in any case, even if provider does not implement Listener, so we can use "file" storage as memory - all the persistent definitions are loaded on startup, but then API allows to manipulate proxies in memory. Otherwise api calls just stuck because channel is busy. 
