### PR TITLE
Fix table layout by escaping the `||` character

### DIFF
--- a/docs/plugins/cb.md
+++ b/docs/plugins/cb.md
@@ -32,4 +32,4 @@ Configuration | Description
 | error_percent_threshold     | Causes circuits to open once the rolling measure of errors exceeds this percent of requests |
 | request_volume_threshold    | Is the minimum number of requests needed before a circuit can be tripped due to health |
 | sleep_window                | Is how long, in milliseconds, to wait after a circuit opens before testing for recovery |
-| predicate                   | The rule that we will check to define if the request was successful or not. You have access to `statusCode` and all the `request` object. Defaults to `statusCode == 0 || statusCode >= 500` |
+| predicate                   | The rule that we will check to define if the request was successful or not. You have access to `statusCode` and all the `request` object. Defaults to `statusCode == 0 \|\| statusCode >= 500` |


### PR DESCRIPTION
## What does this PR do?
While I was reading the docs on [Gitbook](https://hellofresh.gitbooks.io/janus/plugins/cb.html), I noticed that the table was broken and it seems that the `||` needs to be escaped.

[https://i.imgur.com/J3jX95E.png](https://i.imgur.com/J3jX95E.png)

