### PR TITLE
PT-2440 Missing config file should not be an error

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -21,11 +21,11 @@ func initConfig() {
 	var err error
 	globalConfig, err = config.Load(configFile)
 	if nil != err {
-		log.WithError(err).Error("Could not load configurations from file - trying environment configurations instead.")
+		log.WithError(err).Info("Could not load configurations from file - trying environment configurations instead.")
 
 		globalConfig, err = config.LoadEnv()
 		if nil != err {
-			log.WithError(err).Error("Could not load configurations from environment")
+			log.WithError(err).Error("Could not load configurations from environment variables")
 		}
 	}
 }


### PR DESCRIPTION
## What does this PR do?
Env variables is more preferred way of loading configurtions, especially in docker/k8s world, so missing config file should not be an error.
