### PR TITLE
Add additional trace attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- None
+- Added additional attributes to ochttp spans
 
 # 3.8.6
 


### PR DESCRIPTION
## What does this PR do?
Adds additional attributes to http span started by `ochttp.Handler`.