### PR TITLE
Add request-id to error handler logs

### DIFF
--- a/pkg/errors/error_test.go
+++ b/pkg/errors/error_test.go
@@ -12,7 +12,8 @@ import (
 
 func TestErrorWithCustomError(t *testing.T) {
 	w := httptest.NewRecorder()
-	Handler(w, New(http.StatusBadRequest, http.StatusText(http.StatusBadRequest)))
+	r, _ := http.NewRequest(http.MethodGet, "/hello/test", nil)
+	Handler(w, r, New(http.StatusBadRequest, http.StatusText(http.StatusBadRequest)))
 
 	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -20,7 +21,8 @@ func TestErrorWithCustomError(t *testing.T) {
 
 func TestErrorWithDefaultError(t *testing.T) {
 	w := httptest.NewRecorder()
-	Handler(w, errorsBase.New(http.StatusText(http.StatusBadRequest)))
+	r, _ := http.NewRequest(http.MethodGet, "/hello/test", nil)
+	Handler(w, r, errorsBase.New(http.StatusText(http.StatusBadRequest)))
 
 	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
 	assert.Equal(t, http.StatusInternalServerError, w.Code)

--- a/pkg/middleware/host_matcher.go
+++ b/pkg/middleware/host_matcher.go
@@ -46,7 +46,7 @@ func (h *HostMatcher) Handler(handler http.Handler) http.Handler {
 
 		err := errors.ErrRouteNotFound
 		log.WithError(err).Error("The host didn't match any of the provided hosts")
-		errors.Handler(w, err)
+		errors.Handler(w, r, err)
 	})
 }
 

--- a/pkg/middleware/logger.go
+++ b/pkg/middleware/logger.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/felixge/httpsnoop"
+	"github.com/hellofresh/janus/pkg/observability"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -22,7 +23,7 @@ func (m *Logger) Handler(handler http.Handler) http.Handler {
 		log.WithFields(log.Fields{"method": r.Method, "path": r.URL.Path}).Debug("Started request")
 
 		fields := log.Fields{
-			"request-id":  RequestIDFromContext(r.Context()),
+			"request-id":  observability.RequestIDFromContext(r.Context()),
 			"method":      r.Method,
 			"host":        r.Host,
 			"request":     r.RequestURI,

--- a/pkg/middleware/request_id.go
+++ b/pkg/middleware/request_id.go
@@ -1,9 +1,9 @@
 package middleware
 
 import (
-	"context"
 	"net/http"
 
+	"github.com/hellofresh/janus/pkg/observability"
 	"github.com/satori/go.uuid"
 )
 
@@ -25,22 +25,6 @@ func RequestID(handler http.Handler) http.Handler {
 		r.Header.Set(requestIDHeader, requestID)
 		w.Header().Set(requestIDHeader, requestID)
 
-		ctx := r.Context()
-		ctx = context.WithValue(ctx, reqIDKey, requestID)
-
-		handler.ServeHTTP(w, r.WithContext(ctx))
+		handler.ServeHTTP(w, r.WithContext(observability.RequestIDToContext(r.Context(), requestID)))
 	})
-}
-
-// RequestIDFromContext tries to extract request ID from context if present, otherwise returns empty string
-func RequestIDFromContext(ctx context.Context) string {
-	if ctx == nil {
-		panic("Can not get request ID from empty context")
-	}
-
-	if requestID, ok := ctx.Value(reqIDKey).(string); ok {
-		return requestID
-	}
-
-	return ""
 }

--- a/pkg/observability/request_id.go
+++ b/pkg/observability/request_id.go
@@ -1,0 +1,29 @@
+package observability
+
+import "context"
+
+type reqIDKeyType int
+
+const reqIDKey reqIDKeyType = iota
+
+// RequestIDToContext puts a request ID to context for future use
+func RequestIDToContext(ctx context.Context, requestID string) context.Context {
+	if ctx == nil {
+		panic("Can not put request ID to empty context")
+	}
+
+	return context.WithValue(ctx, reqIDKey, requestID)
+}
+
+// RequestIDFromContext tries to extract request ID from context if present, otherwise returns empty string
+func RequestIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		panic("Can not get request ID from empty context")
+	}
+
+	if requestID, ok := ctx.Value(reqIDKey).(string); ok {
+		return requestID
+	}
+
+	return ""
+}

--- a/pkg/plugin/basic/handler.go
+++ b/pkg/plugin/basic/handler.go
@@ -30,7 +30,7 @@ func (c *Handler) Index() http.HandlerFunc {
 		span.End()
 
 		if err != nil {
-			errors.Handler(w, err)
+			errors.Handler(w, r, err)
 			return
 		}
 
@@ -47,7 +47,7 @@ func (c *Handler) Show() http.HandlerFunc {
 		span.End()
 
 		if err != nil {
-			errors.Handler(w, err)
+			errors.Handler(w, r, err)
 			return
 		}
 
@@ -66,18 +66,18 @@ func (c *Handler) Update() http.HandlerFunc {
 		span.End()
 
 		if user == nil {
-			errors.Handler(w, ErrUserNotFound)
+			errors.Handler(w, r, ErrUserNotFound)
 			return
 		}
 
 		if err != nil {
-			errors.Handler(w, err)
+			errors.Handler(w, r, err)
 			return
 		}
 
 		err = json.NewDecoder(r.Body).Decode(user)
 		if err != nil {
-			errors.Handler(w, err)
+			errors.Handler(w, r, err)
 			return
 		}
 
@@ -86,7 +86,7 @@ func (c *Handler) Update() http.HandlerFunc {
 		span.End()
 
 		if err != nil {
-			errors.Handler(w, errors.New(http.StatusBadRequest, err.Error()))
+			errors.Handler(w, r, errors.New(http.StatusBadRequest, err.Error()))
 			return
 		}
 
@@ -101,7 +101,7 @@ func (c *Handler) Create() http.HandlerFunc {
 
 		err := json.NewDecoder(r.Body).Decode(user)
 		if nil != err {
-			errors.Handler(w, err)
+			errors.Handler(w, r, err)
 			return
 		}
 
@@ -110,8 +110,8 @@ func (c *Handler) Create() http.HandlerFunc {
 		span.End()
 
 		if err != ErrUserNotFound {
-			log.WithError(err).Warn("An error occurrend when looking for an user")
-			errors.Handler(w, ErrUserExists)
+			log.WithError(err).Warn("An error occurred when looking for an user")
+			errors.Handler(w, r, ErrUserExists)
 			return
 		}
 
@@ -120,7 +120,7 @@ func (c *Handler) Create() http.HandlerFunc {
 		span.End()
 
 		if err != nil {
-			errors.Handler(w, errors.New(http.StatusBadRequest, err.Error()))
+			errors.Handler(w, r, errors.New(http.StatusBadRequest, err.Error()))
 			return
 		}
 
@@ -139,7 +139,7 @@ func (c *Handler) Delete() http.HandlerFunc {
 		span.End()
 
 		if err != nil {
-			errors.Handler(w, err)
+			errors.Handler(w, r, err)
 			return
 		}
 

--- a/pkg/plugin/basic/middleware.go
+++ b/pkg/plugin/basic/middleware.go
@@ -20,7 +20,7 @@ func NewBasicAuth(repo Repository) func(http.Handler) http.Handler {
 
 			username, password, authOK := r.BasicAuth()
 			if !authOK {
-				errors.Handler(w, ErrNotAuthorized)
+				errors.Handler(w, r, ErrNotAuthorized)
 				return
 			}
 
@@ -28,7 +28,7 @@ func NewBasicAuth(repo Repository) func(http.Handler) http.Handler {
 			users, err := repo.FindAll()
 			if err != nil {
 				log.WithError(err).Error("Error when getting all users")
-				errors.Handler(w, errors.New(http.StatusInternalServerError, "there was an error when looking for users"))
+				errors.Handler(w, r, errors.New(http.StatusInternalServerError, "there was an error when looking for users"))
 				return
 			}
 
@@ -41,7 +41,7 @@ func NewBasicAuth(repo Repository) func(http.Handler) http.Handler {
 
 			if !found {
 				logger.Debug("Invalid user/password provided.")
-				errors.Handler(w, ErrNotAuthorized)
+				errors.Handler(w, r, ErrNotAuthorized)
 				return
 			}
 

--- a/pkg/plugin/bodylmt/middleware.go
+++ b/pkg/plugin/bodylmt/middleware.go
@@ -25,7 +25,7 @@ func NewBodyLimitMiddleware(limit string) func(http.Handler) http.Handler {
 
 			// Based on content length
 			if r.ContentLength > int64(limit) {
-				errors.Handler(w, ErrRequestEntityTooLarge)
+				errors.Handler(w, r, ErrRequestEntityTooLarge)
 				return
 			}
 

--- a/pkg/plugin/cb/middleware.go
+++ b/pkg/plugin/cb/middleware.go
@@ -58,7 +58,7 @@ func NewCBMiddleware(cfg Config) func(http.Handler) http.Handler {
 
 			if err != nil {
 				logger.WithError(err).Error("Request failed on the cb middleware")
-				janusErr.Handler(w, errors.Wrap(err, "request failed"))
+				janusErr.Handler(w, r, errors.Wrap(err, "request failed"))
 			}
 		})
 	}

--- a/pkg/plugin/oauth2/handlers.go
+++ b/pkg/plugin/oauth2/handlers.go
@@ -28,7 +28,7 @@ func (c *Controller) Get() http.HandlerFunc {
 		span.End()
 
 		if err != nil {
-			errors.Handler(w, err)
+			errors.Handler(w, r, err)
 			return
 		}
 
@@ -45,7 +45,7 @@ func (c *Controller) GetBy() http.HandlerFunc {
 		span.End()
 
 		if err != nil {
-			errors.Handler(w, err)
+			errors.Handler(w, r, err)
 			return
 		}
 
@@ -64,18 +64,18 @@ func (c *Controller) PutBy() http.HandlerFunc {
 		span.End()
 
 		if oauth.Name == "" {
-			errors.Handler(w, ErrOauthServerNotFound)
+			errors.Handler(w, r, ErrOauthServerNotFound)
 			return
 		}
 
 		if err != nil {
-			errors.Handler(w, err)
+			errors.Handler(w, r, err)
 			return
 		}
 
 		err = json.NewDecoder(r.Body).Decode(oauth)
 		if err != nil {
-			errors.Handler(w, err)
+			errors.Handler(w, r, err)
 			return
 		}
 
@@ -84,7 +84,7 @@ func (c *Controller) PutBy() http.HandlerFunc {
 		span.End()
 
 		if err != nil {
-			errors.Handler(w, errors.New(http.StatusBadRequest, err.Error()))
+			errors.Handler(w, r, errors.New(http.StatusBadRequest, err.Error()))
 			return
 		}
 
@@ -98,7 +98,7 @@ func (c *Controller) Post() http.HandlerFunc {
 		oauth := NewOAuth()
 		err := json.NewDecoder(r.Body).Decode(oauth)
 		if nil != err {
-			errors.Handler(w, err)
+			errors.Handler(w, r, err)
 			return
 		}
 
@@ -107,7 +107,7 @@ func (c *Controller) Post() http.HandlerFunc {
 		span.End()
 
 		if nil != err {
-			errors.Handler(w, err)
+			errors.Handler(w, r, err)
 			return
 		}
 
@@ -125,7 +125,7 @@ func (c *Controller) DeleteBy() http.HandlerFunc {
 		span.End()
 
 		if err != nil {
-			errors.Handler(w, err)
+			errors.Handler(w, r, err)
 			return
 		}
 

--- a/pkg/plugin/oauth2/middleware.go
+++ b/pkg/plugin/oauth2/middleware.go
@@ -56,7 +56,7 @@ func NewKeyExistsMiddleware(manager Manager) func(http.Handler) http.Handler {
 				logger.Warn("Attempted access with malformed header, no auth header found.")
 				statsClient.TrackOperation(tokensSection, bucket.MetricOperation{"key-exists", "header"}, nil, false)
 				stats.Record(r.Context(), obs.MOAuth2MissingHeader.M(1))
-				errors.Handler(w, ErrAuthorizationFieldNotFound)
+				errors.Handler(w, r, ErrAuthorizationFieldNotFound)
 				return
 			}
 			statsClient.TrackOperation(tokensSection, bucket.MetricOperation{"key-exists", "header"}, nil, true)
@@ -65,7 +65,7 @@ func NewKeyExistsMiddleware(manager Manager) func(http.Handler) http.Handler {
 				logger.Warn("Bearer token malformed")
 				statsClient.TrackOperation(tokensSection, bucket.MetricOperation{"key-exists", "malformed"}, nil, false)
 				stats.Record(r.Context(), obs.MOAuth2MalformedHeader.M(1))
-				errors.Handler(w, ErrBearerMalformed)
+				errors.Handler(w, r, ErrBearerMalformed)
 				return
 			}
 			statsClient.TrackOperation(tokensSection, bucket.MetricOperation{"key-exists", "malformed"}, nil, true)
@@ -85,7 +85,7 @@ func NewKeyExistsMiddleware(manager Manager) func(http.Handler) http.Handler {
 					"origin": r.RemoteAddr,
 					"key":    accessToken,
 				}).Debug("Attempted access with invalid key.")
-				errors.Handler(w, ErrAccessTokenNotAuthorized)
+				errors.Handler(w, r, ErrAccessTokenNotAuthorized)
 				return
 			}
 

--- a/pkg/plugin/retry/middleware.go
+++ b/pkg/plugin/retry/middleware.go
@@ -58,7 +58,7 @@ func NewRetryMiddleware(cfg Config) func(http.Handler) http.Handler {
 			}, cfg.Attempts, time.Duration(cfg.Backoff)); err != nil {
 				statsClient := metrics.WithContext(r.Context())
 				statsClient.SetHTTPRequestSection(proxySection).TrackRequest(r, nil, false).ResetHTTPRequestSection()
-				janusErr.Handler(w, errors.Wrap(err, "request failed too many times"))
+				janusErr.Handler(w, r, errors.Wrap(err, "request failed too many times"))
 			}
 		})
 	}

--- a/pkg/proxy/reverse_proxy.go
+++ b/pkg/proxy/reverse_proxy.go
@@ -9,8 +9,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi"
-	"github.com/hellofresh/janus/pkg/middleware"
-	obs "github.com/hellofresh/janus/pkg/observability"
+	"github.com/hellofresh/janus/pkg/observability"
 	"github.com/hellofresh/janus/pkg/proxy/balancer"
 	"github.com/hellofresh/janus/pkg/router"
 	"github.com/hellofresh/stats-go/bucket"
@@ -102,7 +101,7 @@ func createDirector(proxyDefinition *Definition, balancer balancer.Balancer, sta
 		// RequestID is not enabled.
 		log.WithFields(log.Fields{
 			"request":          originalURI,
-			"request-id":       middleware.RequestIDFromContext(req.Context()),
+			"request-id":       observability.RequestIDFromContext(req.Context()),
 			"upstream-host":    req.URL.Host,
 			"upstream-request": req.URL.RequestURI(),
 		}).Info("Proxying request to the following upstream")
@@ -113,7 +112,7 @@ func createDirector(proxyDefinition *Definition, balancer balancer.Balancer, sta
 		addTraceAttributes(req)
 
 		// Insert additional tags
-		ctx, _ := tag.New(req.Context(), tag.Insert(obs.KeyUpstreamPath, upstream.Target))
+		ctx, _ := tag.New(req.Context(), tag.Insert(observability.KeyUpstreamPath, upstream.Target))
 		*req = *req.WithContext(ctx)
 	}
 }
@@ -135,7 +134,7 @@ func addTraceAttributes(req *http.Request) {
 		trace.StringAttribute("http.host", host),
 		trace.StringAttribute("http.referrer", req.Referer()),
 		trace.StringAttribute("http.remote_address", req.RemoteAddr),
-		trace.StringAttribute("request.id", middleware.RequestIDFromContext(ctx)),
+		trace.StringAttribute("request.id", observability.RequestIDFromContext(ctx)),
 	)
 }
 

--- a/pkg/test/handler.go
+++ b/pkg/test/handler.go
@@ -21,5 +21,5 @@ func FailWith(statusCode int) http.Handler {
 
 // RecoveryHandler represents the recovery handler
 func RecoveryHandler(w http.ResponseWriter, r *http.Request, err interface{}) {
-	errors.Handler(w, err)
+	errors.Handler(w, r, err)
 }

--- a/pkg/web/api_handler.go
+++ b/pkg/web/api_handler.go
@@ -51,7 +51,7 @@ func (c *APIHandler) GetBy() http.HandlerFunc {
 		span.End()
 
 		if cfg == nil {
-			errors.Handler(w, api.ErrAPIDefinitionNotFound)
+			errors.Handler(w, r, api.ErrAPIDefinitionNotFound)
 			return
 		}
 
@@ -70,19 +70,19 @@ func (c *APIHandler) PutBy() http.HandlerFunc {
 		span.End()
 
 		if cfg == nil {
-			errors.Handler(w, api.ErrAPIDefinitionNotFound)
+			errors.Handler(w, r, api.ErrAPIDefinitionNotFound)
 			return
 		}
 
 		err = json.NewDecoder(r.Body).Decode(cfg)
 		if err != nil {
-			errors.Handler(w, err)
+			errors.Handler(w, r, err)
 			return
 		}
 
 		isValid, err := cfg.Validate()
 		if false == isValid && err != nil {
-			errors.Handler(w, errors.New(http.StatusBadRequest, err.Error()))
+			errors.Handler(w, r, errors.New(http.StatusBadRequest, err.Error()))
 			return
 		}
 
@@ -90,7 +90,7 @@ func (c *APIHandler) PutBy() http.HandlerFunc {
 		for _, plg := range cfg.Plugins {
 			isValid, err := plugin.ValidateConfig(plg.Name, plg.Config)
 			if !isValid || err != nil {
-				errors.Handler(w, errors.New(http.StatusBadRequest, err.Error()))
+				errors.Handler(w, r, errors.New(http.StatusBadRequest, err.Error()))
 				return
 			}
 		}
@@ -102,7 +102,7 @@ func (c *APIHandler) PutBy() http.HandlerFunc {
 		span.End()
 
 		if existingCfg != nil && existingCfg.Name != cfg.Name {
-			errors.Handler(w, api.ErrAPIListenPathExists)
+			errors.Handler(w, r, api.ErrAPIListenPathExists)
 			return
 		}
 
@@ -124,13 +124,13 @@ func (c *APIHandler) Post() http.HandlerFunc {
 
 		err := json.NewDecoder(r.Body).Decode(cfg)
 		if nil != err {
-			errors.Handler(w, err)
+			errors.Handler(w, r, err)
 			return
 		}
 
 		isValid, err := cfg.Validate()
 		if false == isValid && err != nil {
-			errors.Handler(w, errors.New(http.StatusBadRequest, err.Error()))
+			errors.Handler(w, r, errors.New(http.StatusBadRequest, err.Error()))
 			return
 		}
 
@@ -138,7 +138,7 @@ func (c *APIHandler) Post() http.HandlerFunc {
 		for _, plg := range cfg.Plugins {
 			isValid, err := plugin.ValidateConfig(plg.Name, plg.Config)
 			if !isValid || err != nil {
-				errors.Handler(w, errors.New(http.StatusBadRequest, err.Error()))
+				errors.Handler(w, r, errors.New(http.StatusBadRequest, err.Error()))
 				return
 			}
 		}
@@ -148,7 +148,7 @@ func (c *APIHandler) Post() http.HandlerFunc {
 		span.End()
 
 		if err != nil || exists {
-			errors.Handler(w, err)
+			errors.Handler(w, r, err)
 			return
 		}
 
@@ -173,7 +173,7 @@ func (c *APIHandler) DeleteBy() http.HandlerFunc {
 		name := router.URLParam(r, "name")
 		cfg := c.findByName(name)
 		if cfg == nil {
-			errors.Handler(w, api.ErrAPIDefinitionNotFound)
+			errors.Handler(w, r, api.ErrAPIDefinitionNotFound)
 			return
 		}
 


### PR DESCRIPTION
## What does this PR do?
Adds `request-id` to errors handler to make it easier to track source of error like `no API found with those values`.
