### PR TITLE
PT-3583 Use memory repository when no mongo connection for basic auth pligin

### DIFF
--- a/pkg/plugin/basic/errors.go
+++ b/pkg/plugin/basic/errors.go
@@ -13,8 +13,6 @@ var (
 	ErrUserNotFound = errors.New(http.StatusNotFound, "user not found")
 	// ErrUserExists is used when an user already exists
 	ErrUserExists = errors.New(http.StatusNotFound, "user already exists")
-	// ErrInvalidMongoDBSession is used when mongodb is not being used
-	ErrInvalidMongoDBSession = errors.New(http.StatusNotFound, "invalid mongodb session given")
 	// ErrInvalidAdminRouter is used when an invalid admin router is given
 	ErrInvalidAdminRouter = errors.New(http.StatusNotFound, "invalid admin router given")
 )

--- a/pkg/plugin/basic/setup.go
+++ b/pkg/plugin/basic/setup.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hellofresh/janus/pkg/plugin"
 	"github.com/hellofresh/janus/pkg/proxy"
 	"github.com/hellofresh/janus/pkg/router"
+	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -49,17 +50,22 @@ func onStartup(event interface{}) error {
 		return errors.New("could not convert event to startup type")
 	}
 
+	var repo Repository
 	if e.MongoSession == nil {
-		return ErrInvalidMongoDBSession
+		log.Debug("Mongo session is not set, using memory repository for basic auth plugin")
+
+		repo = NewInMemoryRepository()
+	} else {
+		log.Debug("Mongo session is set, using mongo repository for basic auth plugin")
+
+		repo, err = NewMongoRepository(e.MongoSession)
+		if err != nil {
+			return err
+		}
 	}
 
 	if adminRouter == nil {
 		return ErrInvalidAdminRouter
-	}
-
-	repo, err = NewMongoRepository(e.MongoSession)
-	if err != nil {
-		return err
 	}
 
 	handlers := NewHandler(repo)

--- a/pkg/plugin/basic/setup.go
+++ b/pkg/plugin/basic/setup.go
@@ -50,7 +50,6 @@ func onStartup(event interface{}) error {
 		return errors.New("could not convert event to startup type")
 	}
 
-	var repo Repository
 	if e.MongoSession == nil {
 		log.Debug("Mongo session is not set, using memory repository for basic auth plugin")
 

--- a/pkg/plugin/basic/setup_test.go
+++ b/pkg/plugin/basic/setup_test.go
@@ -26,14 +26,10 @@ func TestSetup(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestOnStartupMissingMongoSession(t *testing.T) {
-	event := plugin.OnStartup{Register: proxy.NewRegister(proxy.WithRouter(router.NewChiRouter()))}
-	err := onStartup(event)
-	require.Error(t, err)
-	require.IsType(t, ErrInvalidMongoDBSession, err)
-}
-
 func TestOnStartupMissingAdminRouter(t *testing.T) {
+	// reset admin router to avoid dependency from another test
+	adminRouter = nil
+
 	event := plugin.OnStartup{}
 	err := onStartup(event)
 	require.Error(t, err)


### PR DESCRIPTION
## What does this PR do?
Basic auth plugin falls back to memory repository when no mongo session avaiable. This is the case when file backend is used for api definitions.

Refs https://github.com/hellofresh/janus/issues/385
