### PR TITLE
Skip upstream election logic if there is only one possible host

### DIFF
--- a/pkg/proxy/balancer/rr.go
+++ b/pkg/proxy/balancer/rr.go
@@ -21,6 +21,10 @@ func (b *RoundrobinBalancer) Elect(hosts []*Target) (*Target, error) {
 		return nil, ErrEmptyBackendList
 	}
 
+	if len(hosts) == 1 {
+		return hosts[0], nil
+	}
+
 	if b.current >= len(hosts) {
 		b.current = 0
 	}

--- a/pkg/proxy/balancer/weight.go
+++ b/pkg/proxy/balancer/weight.go
@@ -26,10 +26,6 @@ func (b *WeightBalancer) Elect(hosts []*Target) (*Target, error) {
 		return nil, ErrEmptyBackendList
 	}
 
-	if len(hosts) == 1 {
-		return hosts[0], nil
-	}
-
 	totalWeight := 0
 	for _, host := range hosts {
 		totalWeight += host.Weight
@@ -37,6 +33,10 @@ func (b *WeightBalancer) Elect(hosts []*Target) (*Target, error) {
 
 	if totalWeight <= 0 {
 		return nil, ErrZeroWeight
+	}
+
+	if len(hosts) == 1 {
+		return hosts[0], nil
 	}
 
 	r := rand.Intn(totalWeight)

--- a/pkg/proxy/balancer/weight.go
+++ b/pkg/proxy/balancer/weight.go
@@ -26,6 +26,10 @@ func (b *WeightBalancer) Elect(hosts []*Target) (*Target, error) {
 		return nil, ErrEmptyBackendList
 	}
 
+	if len(hosts) == 1 {
+		return hosts[0], nil
+	}
+
 	totalWeight := 0
 	for _, host := range hosts {
 		totalWeight += host.Weight


### PR DESCRIPTION
Simply return an upstream host if there is only one possible host.

A quick simple proxying benchmark with only one upstream host using round-robin and 50 concurrent requests shows a ±10% speedup (4500rps » 5000 rps) and eliminates a small number of responses with status code 500 presumably due to mutexes used on round robin-election strategy.