### PR TITLE
PT-4110 Fix rate limiting plugin

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -487,7 +487,7 @@
   revision = "1731857f09b1f38450e2c12409748407822dc6be"
 
 [[projects]]
-  digest = "1:4e065a1e2b1e517d6e5073ff05ba5aadbfad782ade9a8f006bf0abdfd29c77e2"
+  digest = "1:5c1c48d01a6b1271144921d079e88cf3918d0d84d6d32640c3afcba3023af44a"
   name = "github.com/ulule/limiter"
   packages = [
     ".",
@@ -497,8 +497,8 @@
     "drivers/store/redis",
   ]
   pruneopts = ""
-  revision = "0d25c13867d07314999d01525f9d69d40c6bf235"
-  version = "v2.1.0"
+  revision = "38b2a440be905c8be884fd5e114dc893a64e5d81"
+  version = "v2.2.2"
 
 [[projects]]
   digest = "1:ad67dfd3799a2c58f6c65871dd141d8b53f61f600aec48ce8d7fa16a4d5476f8"

--- a/pkg/plugin/rate/rate_limit_logger.go
+++ b/pkg/plugin/rate/rate_limit_logger.go
@@ -30,7 +30,7 @@ func NewRateLimitLogger(lmt *limiter.Limiter, statsClient client.Client) func(ha
 				log.WithFields(log.Fields{
 					"ip_address":  limiterIP.String(),
 					"request_uri": r.RequestURI,
-				}).Warning("Rate Limit exceded for this IP")
+				}).Warning("Rate Limit exceeded for this IP")
 			}
 
 			trackLimitState(lmt, statsClient, limiterIP, r)

--- a/pkg/plugin/rate/setup.go
+++ b/pkg/plugin/rate/setup.go
@@ -86,7 +86,7 @@ func setupRateLimit(def *proxy.RouterDefinition, rawConfig plugin.Config) error 
 
 	limiterInstance := limiter.New(limiterStore, rate)
 	def.AddMiddleware(NewRateLimitLogger(limiterInstance, statsClient))
-	def.AddMiddleware(stdlib.NewMiddleware(limiterInstance).Handler)
+	def.AddMiddleware(stdlib.NewMiddleware(limiterInstance, stdlib.WithForwardHeader(true)).Handler)
 
 	return nil
 }


### PR DESCRIPTION
## What does this PR do?
This PR fixes the rate-limiting plugin in Janus. Now it will use `X-Forwarded-For` and `X-Real-IP` HTTP headers to fetch IP for rate-limiting.
