### PR TITLE
PT-4186 Add trust_forward_headers configuration to rate-limit plugin

### DIFF
--- a/docs/plugins/rate_limit.md
+++ b/docs/plugins/rate_limit.md
@@ -12,18 +12,18 @@ The plain rate limit config:
     "config": {
         "limit": "10-S",
         "policy": "local",
-        "trust_forward_header": false
+        "trust_forward_headers": false
     }
 }
 ```
 
 | Configuration        | Description                                                                                                                                                                                                                                                 |
 |----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| limit                | Defines the limit rule for the proxy. i.e. 5 reqs/second: `5-S`, 10 reqs/minute: `10-M`, 1000 reqs/hour: `1000-H`                                                                                                                                           |
-| policy               | The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local` (counters will be stored locally in-memory on the node) and `redis` (counters are stored on a Redis server and will be shared across the nodes). |
-| redis.dsn            | The DSN for the redis instance/cluster to be used                                                                                                                                                                                                           |
-| redis.prefix         | A prefix to be used on redis keys. It defaults to `limiter`                                                                                                                                                                                                 |                                                        |
-| trust_forward_header | If set to True, `X-Forwarded-For` and `X-Real-IP` headers will be used instead of the source ip. Defaults to False.                                                                                                                                         |
+| limit                 | Defines the limit rule for the proxy. i.e. 5 reqs/second: `5-S`, 10 reqs/minute: `10-M`, 1000 reqs/hour: `1000-H`                                                                                                                                           |
+| policy                | The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local` (counters will be stored locally in-memory on the node) and `redis` (counters are stored on a Redis server and will be shared across the nodes). |
+| redis.dsn             | The DSN for the redis instance/cluster to be used                                                                                                                                                                                                           |
+| redis.prefix          | A prefix to be used on redis keys. It defaults to `limiter`                                                                                                                                                                                                 |                                                        |
+| trust_forward_headers | If set to True, `X-Forwarded-For` and `X-Real-IP` headers will be used instead of the source ip. Defaults to False.                                                                                                                                         |
 
 ## Headers sent to the client
 

--- a/docs/plugins/rate_limit.md
+++ b/docs/plugins/rate_limit.md
@@ -11,17 +11,19 @@ The plain rate limit config:
     "enabled": true,
     "config": {
         "limit": "10-S",
-        "policy": "local"
+        "policy": "local",
+        "trust_forward_header": false
     }
 }
 ```
 
-| Configuration | Description                                                                                                                                                                                                                                                 |
-|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| limit         | Defines the limit rule for the proxy. i.e. 5 reqs/second: `5-S`, 10 reqs/minute: `10-M`, 1000 reqs/hour: `1000-H`                                                                                                                                           |
-| policy        | The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local` (counters will be stored locally in-memory on the node) and `redis` (counters are stored on a Redis server and will be shared across the nodes). |                                                        |
-| redis.dsn        | The DSN for the redis instance/cluster to be used |                                                        |
-| redis.prefix        | A prefix to be used on redis keys. It defaults to `limiter` |                                                        |
+| Configuration        | Description                                                                                                                                                                                                                                                 |
+|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| limit                | Defines the limit rule for the proxy. i.e. 5 reqs/second: `5-S`, 10 reqs/minute: `10-M`, 1000 reqs/hour: `1000-H`                                                                                                                                           |
+| policy               | The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local` (counters will be stored locally in-memory on the node) and `redis` (counters are stored on a Redis server and will be shared across the nodes). |
+| redis.dsn            | The DSN for the redis instance/cluster to be used                                                                                                                                                                                                           |
+| redis.prefix         | A prefix to be used on redis keys. It defaults to `limiter`                                                                                                                                                                                                 |                                                        |
+| trust_forward_header | If set to True, `X-Forwarded-For` and `X-Real-IP` headers will be used instead of the source ip. Defaults to False.                                                                                                                                         |
 
 ## Headers sent to the client
 

--- a/pkg/plugin/rate/setup.go
+++ b/pkg/plugin/rate/setup.go
@@ -29,9 +29,10 @@ const (
 
 // Config represents a rate limit config
 type Config struct {
-	Limit       string      `json:"limit"`
-	Policy      string      `json:"policy"`
-	RedisConfig redisConfig `json:"redis"`
+	Limit               string      `json:"limit"`
+	Policy              string      `json:"policy"`
+	RedisConfig         redisConfig `json:"redis"`
+	TrustForwardHeaders bool        `json:"trust_forward_headers"`
 }
 
 type redisConfig struct {
@@ -86,7 +87,7 @@ func setupRateLimit(def *proxy.RouterDefinition, rawConfig plugin.Config) error 
 
 	limiterInstance := limiter.New(limiterStore, rate)
 	def.AddMiddleware(NewRateLimitLogger(limiterInstance, statsClient))
-	def.AddMiddleware(stdlib.NewMiddleware(limiterInstance, stdlib.WithForwardHeader(true)).Handler)
+	def.AddMiddleware(stdlib.NewMiddleware(limiterInstance, stdlib.WithForwardHeader(config.TrustForwardHeaders)).Handler)
 
 	return nil
 }

--- a/pkg/plugin/rate/setup_test.go
+++ b/pkg/plugin/rate/setup_test.go
@@ -13,6 +13,7 @@ func TestRateLimitConfig(t *testing.T) {
 	rawConfig := map[string]interface{}{
 		"limit":  "10-S",
 		"policy": "local",
+		"trust_forward_headers": true,
 	}
 
 	err := plugin.Decode(rawConfig, &config)
@@ -20,6 +21,7 @@ func TestRateLimitConfig(t *testing.T) {
 
 	assert.Equal(t, "10-S", config.Limit)
 	assert.Equal(t, "local", config.Policy)
+	assert.True(t, config.TrustForwardHeaders)
 }
 
 func TestInvalidRateLimitConfig(t *testing.T) {
@@ -66,5 +68,30 @@ func TestRateLimitPluginInvalidPolicy(t *testing.T) {
 	def := proxy.NewRouterDefinition(proxy.NewDefinition())
 	err := setupRateLimit(def, rawConfig)
 
+	assert.Error(t, err)
+}
+
+func TestRateLimitPluginTrustForwardHeadersDefaultsToFalse(t *testing.T) {
+	var config Config
+	rawConfig := map[string]interface{}{
+		"limit":  "10-S",
+		"policy": "local",
+	}
+
+	err := plugin.Decode(rawConfig, &config)
+	assert.NoError(t, err)
+
+	assert.False(t, config.TrustForwardHeaders)
+}
+
+func TestRateLimitPluginInvalidTrustForwardHeaders(t *testing.T) {
+	var config Config
+	rawConfig := map[string]interface{}{
+		"limit":  "10-S",
+		"policy": "local",
+		"trust_forward_headers": "not_boolean",
+	}
+
+	err := plugin.Decode(rawConfig, &config)
 	assert.Error(t, err)
 }

--- a/pkg/plugin/rate/setup_test.go
+++ b/pkg/plugin/rate/setup_test.go
@@ -11,8 +11,8 @@ import (
 func TestRateLimitConfig(t *testing.T) {
 	var config Config
 	rawConfig := map[string]interface{}{
-		"limit":  "10-S",
-		"policy": "local",
+		"limit":                 "10-S",
+		"policy":                "local",
 		"trust_forward_headers": true,
 	}
 
@@ -87,8 +87,8 @@ func TestRateLimitPluginTrustForwardHeadersDefaultsToFalse(t *testing.T) {
 func TestRateLimitPluginInvalidTrustForwardHeaders(t *testing.T) {
 	var config Config
 	rawConfig := map[string]interface{}{
-		"limit":  "10-S",
-		"policy": "local",
+		"limit":                 "10-S",
+		"policy":                "local",
 		"trust_forward_headers": "not_boolean",
 	}
 


### PR DESCRIPTION
Adds a configuration to Rate Limit Plugin `trust_forward_headers`.  
Defaults to false.

#### Related
https://github.com/hellofresh/janus-dashboard/pull/314
