### PR TITLE
Periodically clear http keep-alive connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Unreleased
--
- None
+- Added `CONN_PURGE_INTERVAL` environment variable as a way to prevent stale http keep-alive connections
 
 # 3.8.8
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -42,6 +42,8 @@
     * [Health Checks](misc/health_checks.md)
     * [Monitoring](misc/monitoring.md)
     * [Tracing](misc/tracing.md)
+* Known Issues
+    * [Stale HTTP Keep-Alive](misc/http_keepalive.md)
 * Upgrade Notes
     * [2.x to 3.x](upgrade/3x.md)
     * [3.6.x to 3.7.x](upgrade/3.7.x.md)

--- a/docs/known_issues/http_keepalive.md
+++ b/docs/known_issues/http_keepalive.md
@@ -1,0 +1,11 @@
+# Stale HTTP Keep-Alive
+
+Janus proxies requests with HTTP keep-alive enabled to reduce resource usage and latency.
+Unless explicitly configured, the proxy uses default idle connection timeout of 90 seconds.
+This means keep-alive connections that are not used for 90 seconds are closed, and the next request will use a fresh connection.    
+
+This creates a stale connection if an endpoint is under constant load – therefore never reaching 90 seconds idle timeout.
+If a DNS update occurs and the target host of the endpoint points to a different address, this connection will still stay alive indefinitely, proxying requests to the wrong address until either Janus is restarted, or the endpoint gets idle long enough to exceed the 90 seconds of the idle connection timeout so it's closed and a new connection is created.
+
+To help with this problem, Janus can be started with an optional environment variable `CONN_PURGE_INTERVAL` that flushes the idle HTTP keep-alive connections periodically. 
+This allows Janus to retain the benefits of HTTP keep-alive connections while limiting the maximum duration of stale connection kept alive.   

--- a/pkg/config/specification.go
+++ b/pkg/config/specification.go
@@ -17,6 +17,7 @@ type Specification struct {
 	MaxIdleConnsPerHost  int           `envconfig:"MAX_IDLE_CONNS_PER_HOST"`
 	BackendFlushInterval time.Duration `envconfig:"BACKEND_FLUSH_INTERVAL"`
 	IdleConnTimeout      time.Duration `envconfig:"IDLE_CONN_TIMEOUT"`
+	ConnPurgeInterval    time.Duration `envconfig:"CONN_PURGE_INTERVAL"`
 	RequestID            bool          `envconfig:"REQUEST_ID_ENABLED"`
 	Log                  logging.LogConfig
 	Web                  Web

--- a/pkg/proxy/register.go
+++ b/pkg/proxy/register.go
@@ -60,13 +60,15 @@ func (p *Register) Add(definition *RouterDefinition) error {
 
 	handler := NewBalancedReverseProxy(definition.Definition, balancerInstance, p.statsClient)
 	handler.FlushInterval = p.flushInterval
-	handler.Transport = transport.New(
-		transport.WithIdleConnTimeout(p.idleConnTimeout),
-		transport.WithIdleConnPurgeTicker(p.idleConnPurgeTicker),
-		transport.WithInsecureSkipVerify(definition.InsecureSkipVerify),
-		transport.WithDialTimeout(time.Duration(definition.ForwardingTimeouts.DialTimeout)),
-		transport.WithResponseHeaderTimeout(time.Duration(definition.ForwardingTimeouts.ResponseHeaderTimeout)),
-	)
+	handler.Transport = &ochttp.Transport{
+		Base: transport.New(
+			transport.WithIdleConnTimeout(p.idleConnTimeout),
+			transport.WithIdleConnPurgeTicker(p.idleConnPurgeTicker),
+			transport.WithInsecureSkipVerify(definition.InsecureSkipVerify),
+			transport.WithDialTimeout(time.Duration(definition.ForwardingTimeouts.DialTimeout)),
+			transport.WithResponseHeaderTimeout(time.Duration(definition.ForwardingTimeouts.ResponseHeaderTimeout)),
+		),
+	}
 
 	if p.matcher.Match(definition.ListenPath) {
 		p.doRegister(p.matcher.Extract(definition.ListenPath), definition, &ochttp.Handler{Handler: handler, IsPublicEndpoint: true})

--- a/pkg/proxy/register_options.go
+++ b/pkg/proxy/register_options.go
@@ -46,3 +46,17 @@ func WithIdleConnTimeout(d time.Duration) RegisterOption {
 		r.idleConnTimeout = d
 	}
 }
+
+// WithIdleConnPurgeTicker purges idle connections on every interval if set
+// this is done to prevent permanent keep-alive on connections with high ops
+func WithIdleConnPurgeTicker(d time.Duration) RegisterOption {
+	var ticker *time.Ticker
+
+	if d != 0 {
+		ticker = time.NewTicker(d)
+	}
+
+	return func(t *Register) {
+		t.idleConnPurgeTicker = ticker
+	}
+}

--- a/pkg/proxy/transport/options.go
+++ b/pkg/proxy/transport/options.go
@@ -36,3 +36,11 @@ func WithIdleConnTimeout(d time.Duration) Option {
 		t.idleConnTimeout = d
 	}
 }
+
+// WithIdleConnPurgeTicker purges idle connections on every interval if set
+// this is done to prevent permanent keep-alive on connections with high ops
+func WithIdleConnPurgeTicker(ticker *time.Ticker) Option {
+	return func(t *transport) {
+		t.idleConnPurgeTicker = ticker
+	}
+}

--- a/pkg/proxy/transport/transport.go
+++ b/pkg/proxy/transport/transport.go
@@ -106,8 +106,10 @@ func New(opts ...Option) *http.Transport {
 				select {
 				case <-t.idleConnPurgeTicker.C:
 					logrus.Info("Closing idle connections")
-					//transport.DisableKeepAlives = true
+					// hack it, with switching it on and off it flushes all connections
+					transport.DisableKeepAlives = true
 					transport.CloseIdleConnections()
+					transport.DisableKeepAlives = false
 				}
 			}
 		}(tr)

--- a/pkg/proxy/transport/transport.go
+++ b/pkg/proxy/transport/transport.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/http2"
 )
 
@@ -105,8 +104,8 @@ func New(opts ...Option) *http.Transport {
 			for {
 				select {
 				case <-t.idleConnPurgeTicker.C:
-					logrus.Info("Closing idle connections")
-					// hack it, with switching it on and off it flushes all connections
+					// This is a hack to prevent (stale) keep-alive connections from being used
+					// Toggling DisableKeepAlives flushes all idle keep-alive connections
 					transport.DisableKeepAlives = true
 					transport.CloseIdleConnections()
 					transport.DisableKeepAlives = false

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -77,8 +77,7 @@ func (s *Server) StartWithContext(ctx context.Context) error {
 		proxy.WithFlushInterval(s.globalConfig.BackendFlushInterval),
 		proxy.WithIdleConnectionsPerHost(s.globalConfig.MaxIdleConnsPerHost),
 		proxy.WithIdleConnTimeout(s.globalConfig.IdleConnTimeout),
-		//proxy.WithIdleConnPurgeTicker(s.globalConfig.IdleConnTimeout),
-		proxy.WithIdleConnPurgeTicker(15*time.Second),
+		proxy.WithIdleConnPurgeTicker(s.globalConfig.ConnPurgeInterval),
 		proxy.WithStatsClient(s.statsClient),
 	)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -77,6 +77,8 @@ func (s *Server) StartWithContext(ctx context.Context) error {
 		proxy.WithFlushInterval(s.globalConfig.BackendFlushInterval),
 		proxy.WithIdleConnectionsPerHost(s.globalConfig.MaxIdleConnsPerHost),
 		proxy.WithIdleConnTimeout(s.globalConfig.IdleConnTimeout),
+		//proxy.WithIdleConnPurgeTicker(s.globalConfig.IdleConnTimeout),
+		proxy.WithIdleConnPurgeTicker(15*time.Second),
 		proxy.WithStatsClient(s.statsClient),
 	)
 


### PR DESCRIPTION
Adds a new optional environment variable `CONN_PURGE_INTERVAL` that periodically clears http keep-alive connections on the proxy.

This is done to limit the errors that occur when a dns change happens on a target host of an endpoint. If this endpoint is under constant load, the connection (with stale dns) will likely be used forever, as `IDLE_CONN_TIMEOUT` of 90 seconds will never be reached.