### PR TITLE
Log correct IP in ratelimiter if we trust forward headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- None
+- Rate limiter logs correct (forwarded) IP if configuration is set to respect `X-Forwarded-For` and `X-Real-IP` headers
 
 
 # 3.8.9

--- a/pkg/plugin/rate/rate_limit_logger.go
+++ b/pkg/plugin/rate/rate_limit_logger.go
@@ -18,14 +18,14 @@ const (
 )
 
 // NewRateLimitLogger logs the IP of blocked users with rate limit
-func NewRateLimitLogger(lmt *limiter.Limiter, statsClient client.Client) func(handler http.Handler) http.Handler {
+func NewRateLimitLogger(lmt *limiter.Limiter, statsClient client.Client, trustForwardHeader bool) func(handler http.Handler) http.Handler {
 	return func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			log.Debug("Starting RateLimitLogger.WriterWrapper middleware")
 
 			m := httpsnoop.CaptureMetrics(handler, w, r)
 
-			limiterIP := limiter.GetIP(r)
+			limiterIP := limiter.GetIP(r, trustForwardHeader)
 			if m.Code == http.StatusTooManyRequests {
 				log.WithFields(log.Fields{
 					"ip_address":  limiterIP.String(),

--- a/pkg/plugin/rate/rate_limit_logger.go
+++ b/pkg/plugin/rate/rate_limit_logger.go
@@ -18,14 +18,14 @@ const (
 )
 
 // NewRateLimitLogger logs the IP of blocked users with rate limit
-func NewRateLimitLogger(lmt *limiter.Limiter, statsClient client.Client, trustForwardHeader bool) func(handler http.Handler) http.Handler {
+func NewRateLimitLogger(lmt *limiter.Limiter, statsClient client.Client, trustForwardHeaders bool) func(handler http.Handler) http.Handler {
 	return func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			log.Debug("Starting RateLimitLogger.WriterWrapper middleware")
 
 			m := httpsnoop.CaptureMetrics(handler, w, r)
 
-			limiterIP := limiter.GetIP(r, trustForwardHeader)
+			limiterIP := limiter.GetIP(r, trustForwardHeaders)
 			if m.Code == http.StatusTooManyRequests {
 				log.WithFields(log.Fields{
 					"ip_address":  limiterIP.String(),

--- a/pkg/plugin/rate/rate_limit_logger_test.go
+++ b/pkg/plugin/rate/rate_limit_logger_test.go
@@ -17,7 +17,7 @@ func TestSuccessfulRateLimitLog(t *testing.T) {
 	rate, _ := limiter.NewRateFromFormatted("100-M")
 	limiterInstance := limiter.New(limiterStore, rate)
 
-	mw := NewRateLimitLogger(limiterInstance, statsClient)
+	mw := NewRateLimitLogger(limiterInstance, statsClient, false)
 	w, err := test.Record(
 		"GET",
 		"/",

--- a/pkg/plugin/rate/setup.go
+++ b/pkg/plugin/rate/setup.go
@@ -86,7 +86,7 @@ func setupRateLimit(def *proxy.RouterDefinition, rawConfig plugin.Config) error 
 	}
 
 	limiterInstance := limiter.New(limiterStore, rate)
-	def.AddMiddleware(NewRateLimitLogger(limiterInstance, statsClient))
+	def.AddMiddleware(NewRateLimitLogger(limiterInstance, statsClient, config.TrustForwardHeaders))
 	def.AddMiddleware(stdlib.NewMiddleware(limiterInstance, stdlib.WithForwardHeader(config.TrustForwardHeaders)).Handler)
 
 	return nil


### PR DESCRIPTION
## What does this PR do?
For the Ratelimit plugin:

When we trust the forwarding headers, we still log the actual source IP address when a ratelimit is triggered.

This PR makes sure we log the correct IP address. 