### PR TITLE
Add debug trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Added trace debugging setting (`tracing.DebugTraceKey`) to get the Trace ID of a debug request in the response
+
 --
 
 # 3.8.10

--- a/janus.sample.toml
+++ b/janus.sample.toml
@@ -195,6 +195,11 @@
   #
   SamplingParam: "0.15"
 
+  # Requests that have X-Debug-Trace header set with the value of DebugTraceKey will
+  # force sampling, and additionally will have the Trace ID returned in their responses
+  # on the X-Debug-Trace header.
+  DebugTraceKey = ""
+
   [tracing.jaeger]
     # SamplingServerURL is the address to the sampling server
     #

--- a/janus.sample.toml
+++ b/janus.sample.toml
@@ -169,13 +169,13 @@
   #
   # Default: None
   #
-  Exporter: "jaeger"
+  Exporter = "jaeger"
 
   # Service name used in the backend
   #
   # Default: "janus"
   #
-  ServiceName: "janus"
+  ServiceName = "janus"
 
   # SamplingStrategy specifies the sampling strategy
   #
@@ -183,7 +183,7 @@
   #
   # Default: "probabilistic"
   #
-  SamplingStrategy: "probabilistic"
+  SamplingStrategy = "probabilistic"
 
   # SamplingParam is an additional value passed to the sampler.
   #
@@ -193,7 +193,7 @@
   #
   # Default: "0.15"
   #
-  SamplingParam: "0.15"
+  SamplingParam = "0.15"
 
   # Requests that have X-Debug-Trace header set with the value of DebugTraceKey will
   # force sampling, and additionally will have the Trace ID returned in their responses
@@ -205,4 +205,4 @@
     #
     # Default: None
     #
-    SamplingServerURL: "localhost:6832"
+    SamplingServerURL = "localhost:6832"

--- a/pkg/config/specification.go
+++ b/pkg/config/specification.go
@@ -155,7 +155,7 @@ func init() {
 	logging.InitDefaults(viper.GetViper(), "log")
 }
 
-//Load configuration variables
+// Load configuration variables
 func Load(configFile string) (*Specification, error) {
 	if configFile != "" {
 		viper.SetConfigFile(configFile)
@@ -183,7 +183,7 @@ func Load(configFile string) (*Specification, error) {
 	return &config, nil
 }
 
-//LoadEnv loads configuration from environment variables
+// LoadEnv loads configuration from environment variables
 func LoadEnv() (*Specification, error) {
 	var config Specification
 

--- a/pkg/config/specification.go
+++ b/pkg/config/specification.go
@@ -112,6 +112,7 @@ type Tracing struct {
 	ServiceName      string        `envconfig:"TRACING_SERVICE_NAME"`
 	SamplingStrategy string        `envconfig:"TRACING_SAMPLING_STRATEGY"`
 	SamplingParam    float64       `envconfig:"TRACING_SAMPLING_PARAM"`
+	DebugTraceKey    string        `envconfig:"TRACING_DEBUG_TRACE_KEY"`
 	JaegerTracing    JaegerTracing `mapstructure:"jaeger"`
 }
 
@@ -149,6 +150,7 @@ func init() {
 	viper.SetDefault("tracing.serviceName", serviceName)
 	viper.SetDefault("tracing.samplingStrategy", "probabilistic")
 	viper.SetDefault("tracing.samplingParam", 0.15)
+	viper.SetDefault("tracing.debugTraceKey", "")
 
 	logging.InitDefaults(viper.GetViper(), "log")
 }

--- a/pkg/config/specification_test.go
+++ b/pkg/config/specification_test.go
@@ -63,4 +63,5 @@ func TestDefaults(t *testing.T) {
 	assert.Equal(t, "janus", globalConfig.Tracing.ServiceName)
 	assert.Equal(t, "probabilistic", globalConfig.Tracing.SamplingStrategy)
 	assert.Equal(t, 0.15, globalConfig.Tracing.SamplingParam)
+	assert.Empty(t, globalConfig.Tracing.DebugTraceKey)
 }

--- a/pkg/middleware/debug_trace.go
+++ b/pkg/middleware/debug_trace.go
@@ -1,0 +1,37 @@
+package middleware
+
+import (
+	"net/http"
+
+	"go.opencensus.io/plugin/ochttp/propagation/b3"
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+)
+
+const (
+	// DebugTraceHeader is the header key used for detecting if
+	// trace should be force sampled and returned in the response
+	DebugTraceHeader = "X-Debug-Trace"
+)
+
+// DebugTrace is a middleware that allows debugging requests by providing the Trace ID
+// back to the caller in the same header in the response
+func DebugTrace(format propagation.HTTPFormat, key string) func(handler http.Handler) http.Handler {
+	return func(handler http.Handler) http.Handler {
+		if format == nil {
+			format = &b3.HTTPFormat{}
+		}
+
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			debugHeader := r.Header.Get(DebugTraceHeader)
+			if debugHeader == key {
+				ctx, span := trace.StartSpan(r.Context(), DebugTraceHeader, trace.WithSampler(trace.AlwaysSample()))
+				r = r.WithContext(ctx)
+				format.SpanContextToRequest(span.SpanContext(), r)
+				w.Header().Add(DebugTraceHeader, span.SpanContext().TraceID.String())
+			}
+
+			handler.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/middleware/debug_trace_test.go
+++ b/pkg/middleware/debug_trace_test.go
@@ -1,0 +1,55 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/magiconair/properties/assert"
+	"go.opencensus.io/plugin/ochttp/propagation/b3"
+)
+
+func TestDebugTrace(t *testing.T) {
+	format := &b3.HTTPFormat{}
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	tests := []struct {
+		testName            string
+		debugHeader         string
+		expectedTraceHeader bool
+	}{
+		{
+			testName:            "'X-Debug-Trace: secret-key' produces response debug header",
+			debugHeader:         "secret-key",
+			expectedTraceHeader: true,
+		},
+		{
+			testName:            "'X-Debug-Trace: 0' does not produce response debug header",
+			debugHeader:         "0",
+			expectedTraceHeader: false,
+		},
+		{
+			testName:            "'X-Debug-Trace: true' does not response debug header",
+			debugHeader:         "true",
+			expectedTraceHeader: false,
+		},
+		{
+			testName:            "'X-Debug-Trace: ' does not produce response debug header",
+			debugHeader:         "",
+			expectedTraceHeader: false,
+		},
+	}
+
+	middleware := DebugTrace(format, "secret-key")
+
+	for _, test := range tests {
+		req, _ := http.NewRequest("GET", "http://hello-world", nil)
+		req.Header.Add("X-Debug-Trace", test.debugHeader)
+
+		rr := httptest.NewRecorder()
+		middleware(testHandler).ServeHTTP(rr, req)
+		hasDebugHeader := rr.Header().Get("X-Debug-Trace") != ""
+		assert.Equal(t, hasDebugHeader, test.expectedTraceHeader, test.testName)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hellofresh/janus/pkg/web"
 	"github.com/hellofresh/stats-go/client"
 	log "github.com/sirupsen/logrus"
+	"go.opencensus.io/plugin/ochttp/propagation/b3"
 )
 
 // Server is the Janus server
@@ -279,6 +280,11 @@ func (s *Server) createRouter() router.Router {
 	// Add RequestID middleware first if enabled, so we could use it in other middlewares, e.g. logger
 	if s.globalConfig.RequestID {
 		r.Use(middleware.RequestID)
+	}
+
+	// Add DebugTraceKey middleware which returns debug header with the Trace ID
+	if s.globalConfig.Tracing.DebugTraceKey != "" {
+		r.Use(middleware.DebugTrace(&b3.HTTPFormat{}, s.globalConfig.Tracing.DebugTraceKey))
 	}
 
 	r.Use(


### PR DESCRIPTION
## What does this PR do?
Adds DebugTrace feature which returns `X-Debug-Trace` response header with the Trace ID. 

Edit: I've reworked the PR so that now we match against some arbitrary key, instead of relying on `true` or `1` set on the request header.
