### PR TITLE
Respect parent sampling decision if not public endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - None
 
+# 3.8.13
+- Changed trace sampling behavior when `TRACING_IS_PUBLIC_ENDPOINT` is set to false
+
 # 3.8.12
 
 ## Added
@@ -55,7 +58,7 @@
 ## Fixed
 
 - Circuit breaker plugin statsd collector prefix
- 
+
 # 3.8.6
 
 ## Updated

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hellofresh/janus/pkg/config"
 	obs "github.com/hellofresh/janus/pkg/observability"
 	"github.com/hellofresh/logging-go"
+	_trace "github.com/hellofresh/opencensus-go-extras/trace"
 	"github.com/hellofresh/stats-go"
 	"github.com/hellofresh/stats-go/bucket"
 	"github.com/hellofresh/stats-go/client"
@@ -171,23 +172,29 @@ func initTracingExporter() {
 	}
 
 	var traceConfig trace.Config
+	var sampler trace.Sampler
 	logger = logger.WithField("tracing.samplingStrategy", globalConfig.Tracing.SamplingStrategy)
 
 	switch globalConfig.Tracing.SamplingStrategy {
 	case "always":
-		traceConfig.DefaultSampler = trace.AlwaysSample()
+		sampler = trace.AlwaysSample()
 		break
 	case "never":
-		traceConfig.DefaultSampler = trace.NeverSample()
+		sampler = trace.NeverSample()
 		break
 	case "probabilistic":
-		traceConfig.DefaultSampler = trace.ProbabilitySampler(globalConfig.Tracing.SamplingParam)
+		sampler = trace.ProbabilitySampler(globalConfig.Tracing.SamplingParam)
 		break
 	default:
 		logger.Warn("Invalid tracing sampling strategy specified")
 		return
 	}
 
+	if !globalConfig.Tracing.IsPublicEndpoint {
+		sampler = _trace.RespectParentSampler(sampler)
+	}
+
+	traceConfig.DefaultSampler = sampler
 	trace.ApplyConfig(traceConfig)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/hashicorp/hcl v0.0.0-20171017181929-23c074d0eceb // indirect
 	github.com/hellofresh/health-go v1.2.6
 	github.com/hellofresh/logging-go v0.1.6
+	github.com/hellofresh/opencensus-go-extras v0.0.0-20191004131501-7bd94f603dcf
 	github.com/hellofresh/stats-go v0.8.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/kelseyhightower/envconfig v1.3.0
@@ -58,7 +59,7 @@ require (
 	github.com/ulule/limiter v2.2.2+incompatible
 	go.opencensus.io v0.18.0
 	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586 // indirect
-	golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7
+	golang.org/x/net v0.0.0-20191003171128-d98b1b443823
 	golang.org/x/oauth2 v0.0.0-20180118004544-b28fcf2b08a1
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58 // indirect
 	golang.org/x/sys v0.0.0-20190825160603-fb81701db80f // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/hellofresh/health-go v1.2.6 h1:qL3H7n3Vjz1tR9F6yvs5jO5IKh0e7ptIt+/1aD
 github.com/hellofresh/health-go v1.2.6/go.mod h1:/lE+J/PDTYpbLHXGSzpRSRaF5fUegajdWaXfYW9dWQQ=
 github.com/hellofresh/logging-go v0.1.6 h1:cY/pZ7Doo+jm+AyFY+MnwBsS8sxF1LN8DEVke2xNmXI=
 github.com/hellofresh/logging-go v0.1.6/go.mod h1:gwpkafA8SxN1O16aSWH4DMCp0+48miJHeeyaI5bl6HY=
+github.com/hellofresh/opencensus-go-extras v0.0.0-20191004131501-7bd94f603dcf h1:Y1JRm9uNFp5Mo5RIGKcR+Q/PbrLfoDrn4kqk8HRJ7s0=
+github.com/hellofresh/opencensus-go-extras v0.0.0-20191004131501-7bd94f603dcf/go.mod h1:lQT0hUJcZDvyxgDnhIeDnK3sPgyEP8Okk3SxCa0M8ZU=
 github.com/hellofresh/stats-go v0.8.0 h1:rWMeTJ/9FU7Hob/Ci7j1wa9pHfNj8LtdUYNC6jLcT2s=
 github.com/hellofresh/stats-go v0.8.0/go.mod h1:8ukhFqK19hqGqF1SyR7ljKBUztsYDxvYRevJ9oOZzhQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
@@ -134,6 +136,7 @@ github.com/tidwall/match v1.0.0 h1:Ym1EcFkp+UQ4ptxfWlW+iMdq5cPH5nEuGzdf/Pb7VmI=
 github.com/tidwall/match v1.0.0/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/ulule/limiter v2.2.2+incompatible h1:1lk9jesmps1ziYHHb4doL7l5hFkYYYA3T8dkNyw7ffY=
 github.com/ulule/limiter v2.2.2+incompatible/go.mod h1:VJx/ZNGmClQDS5F6EmsGqK8j3jz1qJYZ6D9+MdAD+kw=
+go.opencensus.io v0.10.0/go.mod h1:UffZAU+4sDEINUGP/B7UfBBkq4fqLu9zXAX7ke6CHW0=
 go.opencensus.io v0.18.0 h1:Mk5rgZcggtbvtAun5aJzAtjKKN/t0R3jJPlWILlv938=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -145,6 +148,8 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7 h1:fHDIZ2oxGnUZRN6WgWFCbYBjH9uqVPRCUVUDhs0wnbA=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191003171128-d98b1b443823 h1:Ypyv6BNJh07T1pUSrehkLemqPKXhus2MkfktJ91kRh4=
+golang.org/x/net v0.0.0-20191003171128-d98b1b443823/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180118004544-b28fcf2b08a1 h1:gRThnsUxGd2h5EB2AOiqLcAxfMF3Y2LQCeru8REL+p0=
 golang.org/x/oauth2 v0.0.0-20180118004544-b28fcf2b08a1/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=


### PR DESCRIPTION
## What does this PR do?
Currently, if `IsPublicEndpoint` is set to false (and Janus does not ignore propagated traces), and the parent span decides that the trace should not be sampled, Janus still decides whether or not it should sample the trace.  
This causes traces without root span to be recorded if it decides to sample against the parent's decision.

This PR adds a new sampler that ensures sampling decision of the parent span are always respected. If there is no parent span (i.e. it's a direct request to Janus), only then the specified sampler will be used (which currently defaults to [`ProbabilitySampler(0.15)`][1]).

## Links and References
- https://github.com/hellofresh/opencensus-go-extras/blob/master/trace/sampling.go

[1]: https://github.com/hellofresh/janus/blob/63a0fc28d1c2e22c8a4aad03653a8112e95df4d1/pkg/config/specification.go#L152-L153