### PR TITLE
allow option to add valuesFrom env vars

### DIFF
--- a/janus/README.md
+++ b/janus/README.md
@@ -40,6 +40,7 @@ The following table lists the configurable parameters of the Janus chart and the
 | `allowEmptyPassword`                | Allow DB blank passwords                                      | `yes`                                                    |
 | `deployment.replicaCount`           | Number of Janus pod replicas                                  | `2`                                                      |
 | `deployment.minAvailable`           | Creates PDB is min available (must be less than replicaCount) | `1`                                                      |
+| `deployment.valuesFrom`             | Add needed env vars from Kubernetes metadata                  | `POD_NAME`                                               |
 | `deployment.databaseDSN`            | Database connection string                                    | `mongodb://janus-database:27017/janus`                   |
 | `service.type`                      | Kubernetes Service type                                       | `LoadBalancer`                                           |
 | `service.name`                      | Override service name                                         | ``                                                       |

--- a/janus/templates/deployment.yaml
+++ b/janus/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
               name: http-private
               protocol: TCP
           env:
+            {{- if .Values.deployment.valuesFrom }}
+            {{ toYaml .Values.deployment.valuesFrom  | nindent 12 }}
+            {{- end}}
             {{- if .Values.envConfig }}
             {{- range $key, $value := .Values.envConfig }}
             - name: {{ $key | quote }}

--- a/janus/values.yaml
+++ b/janus/values.yaml
@@ -9,6 +9,11 @@ deployment:
   replicaCount: 2
   minAvailable: 1
   databaseDSN: "mongodb://janus-database:27017/janus"
+  valuesFrom:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
 
 imagePullSecrets: []
 


### PR DESCRIPTION
## What does this PR do?
Add the option to have `valuesFrom` env vars in the Janus deployment. 

Example output: 

```
# Source: janus/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: imprecise-robin-janus
  labels:
    app.kubernetes.io/name: janus
    helm.sh/chart: janus-0.1.0
    app.kubernetes.io/instance: imprecise-robin
    app.kubernetes.io/version: "1.0"
    app.kubernetes.io/managed-by: Tiller
spec:
  replicas: 2
  selector:
    matchLabels:
      app.kubernetes.io/name: janus
      app.kubernetes.io/instance: imprecise-robin
  template:
    metadata:
      labels:
        app.kubernetes.io/name: janus
        app.kubernetes.io/instance: imprecise-robin
    spec:
      containers:
        - name: janus
          image: "quay.io/hellofresh/janus:latest"
          imagePullPolicy: Always
          ports:
            - name: http
              containerPort: 8080
              protocol: TCP
            - containerPort: 8081
              name: http-private
              protocol: TCP
          env:
            - name: POD_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
            - name: "DATABASE_DSN"
              value: "mongodb://janus-database:27017/janus"
```
