### PR TITLE
fix labels to use

### DIFF
--- a/janus/README.md
+++ b/janus/README.md
@@ -41,6 +41,7 @@ The following table lists the configurable parameters of the Janus chart and the
 | `deployment.replicaCount`           | Number of Janus pod replicas                                  | `2`                                                      |
 | `deployment.minAvailable`           | Creates PDB is min available (must be less than replicaCount) | `1`                                                      |
 | `deployment.valuesFrom`             | Add needed env vars from Kubernetes metadata                  | `POD_NAME`                                               |
+| `deployment.labels`                 | Add custom labels to the deployment                           | `app: janus`                                             |
 | `deployment.databaseDSN`            | Database connection string                                    | `mongodb://janus-database:27017/janus`                   |
 | `service.type`                      | Kubernetes Service type                                       | `LoadBalancer`                                           |
 | `service.name`                      | Override service name                                         | ``                                                       |

--- a/janus/templates/deployment.yaml
+++ b/janus/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "janus.fullname" . }}
   labels:
 {{ include "janus.labels" . | indent 4 }}
-{{ .Values.deployment.labels | indent 4 }}
+{{ toYaml .Values.deployment.labels | indent 4 }}
 spec:
   replicas: {{ .Values.deployment.replicaCount }}
   selector:
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       labels:
-        {{ .Values.deployment.labels | indent 8 }}
+{{ toYaml .Values.deployment.labels | indent 8 }}
         app.kubernetes.io/name: {{ include "janus.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if or (.Values.deployment.podAnnotations) (.Values.deployment.PodAnnotations) }}


### PR DESCRIPTION
## What does this PR do?
Fix using labels in deployment. 

Example: 

```
# Source: janus/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: insipid-porcupine-janus
  labels:
    app.kubernetes.io/name: janus
    helm.sh/chart: janus-0.1.0
    app.kubernetes.io/instance: insipid-porcupine
    app.kubernetes.io/version: "1.0"
    app.kubernetes.io/managed-by: Tiller
    app: janus
spec:
  replicas: 2
  selector:
    matchLabels:
      app.kubernetes.io/name: janus
      app.kubernetes.io/instance: insipid-porcupine
  template:
    metadata:
      labels:
        app: janus
        app.kubernetes.io/name: janus
        app.kubernetes.io/instance: insipid-porcupine
    spec:
      containers:
        - name: janus
          image: "quay.io/hellofresh/janus:latest"
          imagePullPolicy: Always
          ports:
            - name: http
              containerPort: 8080
              protocol: TCP
            - containerPort: 8081
              name: http-private
              protocol: TCP
          env:
            - name: POD_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
            - name: "DATABASE_DSN"
              value: "mongodb://janus-database:27017/janus"
          resources:  {}
```
