### PR TITLE
split TRACING_JAEGER_SAMPLING_SERVER_URL to two env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 --
 
+# 3.8.19
+
+## Added
+- Added `JAEGER_AGENT_HOST` and `JAEGER_AGENT_PORT` environment variable to allow specifying host and port separately instead of as the full URL.
+   -- Note: you are still able to specify `TRACING_JAEGER_SAMPLING_SERVER_URL`
+
+# 3.8.13, 3.8.14, 3.8.15, 3.8.16, 3.8.17, 3.8.18
+
+## Added
+- experimental helm charts
+
 # 3.8.12
 
 ## Changed

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -199,8 +200,13 @@ func initTracingExporter() {
 }
 
 func initJaegerExporter() (err error) {
+	jaegerURL := globalConfig.Tracing.JaegerTracing.SamplingServerURL
+	if jaegerURL == "" {
+		jaegerURL = fmt.Sprintf("%s:%s", globalConfig.Tracing.JaegerTracing.SamplingServerHost, globalConfig.Tracing.JaegerTracing.SamplingServerPort)
+	}
+
 	jaegerExporter, err := jaeger.NewExporter(jaeger.Options{
-		AgentEndpoint: globalConfig.Tracing.JaegerTracing.SamplingServerURL,
+		AgentEndpoint: jaegerURL,
 		ServiceName:   globalConfig.Tracing.ServiceName,
 	})
 	if err != nil {

--- a/pkg/config/specification.go
+++ b/pkg/config/specification.go
@@ -119,7 +119,9 @@ type Tracing struct {
 
 // JaegerTracing holds the Jaeger tracing configuration
 type JaegerTracing struct {
-	SamplingServerURL string `envconfig:"TRACING_JAEGER_SAMPLING_SERVER_URL"`
+	SamplingServerURL  string `envconfig:"TRACING_JAEGER_SAMPLING_SERVER_URL"`
+	SamplingServerHost string `envconfig:"JAEGER_AGENT_HOST"`
+	SamplingServerPort string `envconfig:"JAEGER_AGENT_PORT"`
 }
 
 func init() {


### PR DESCRIPTION
## What does this PR do?
Split tracing URL to be able to be specified by two seperate envs, one for host, one for port 