### PR TITLE
Make .Values.deployment.databaseDSN optional

### DIFF
--- a/janus/templates/deployment.yaml
+++ b/janus/templates/deployment.yaml
@@ -49,8 +49,10 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
             {{- end }}
+            {{- with .Values.deployment.databaseDSN }}
             - name: "DATABASE_DSN"
-              value: "{{ .Values.deployment.databaseDSN }}"
+              value: "{{ . }}"
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
## What does this PR do?

When using Atlas cloud provider, the MongoDB connection string will contain credentials that people don't want to store as clear text in values.yaml.

Environment variables defined in pod's spec `env` section have higher priority than environment variables defined via `envFrom` (see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#container-v1-core)

> `envFrom`: ... When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. 





This PR makes `.Values.deployment.databaseDSN` optional, so `DATABASE_DSN` can be defined via a Config Map or a Secret.