### PR TITLE
EES-574 Support dynamic port for deps in features tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,14 @@ build:
 	@/bin/sh -c "JANUS_BUILD_ONLY_DEFAULT=$(JANUS_BUILD_ONLY_DEFAULT) PKG_SRC=$(PKG_SRC) VERSION=$(VERSION) ./build/build.sh"
 
 test: lint
-	@echo "$(OK_COLOR)==> Running tests$(NO_COLOR)"
+	@echo "$(OK_COLOR)==> Running unit tests$(NO_COLOR)"
 	@go test -cover ./...
 
-test-integration:
-	@echo "$(OK_COLOR)==> Running tests$(NO_COLOR)"
+test-integration: _mocks
+	@echo "$(OK_COLOR)==> Running integration tests$(NO_COLOR)"
 	@go test -cover -tags=integration ./...
 
-test-features:
+test-features: _mocks
 	@/bin/sh -c "JANUS_BUILD_ONLY_DEFAULT=1 PKG_SRC=$(PKG_SRC) ./build/build.sh"
 	@/bin/sh -c "./build/features.sh"
 
@@ -44,3 +44,6 @@ clean:
 	@echo "$(OK_COLOR)==> Cleaning project$(NO_COLOR)"
 	@go clean
 	@rm -rf bin $GOPATH/bin
+
+_mocks:
+	@/bin/sh -c "./build/mocks.sh"

--- a/assets/docker-compose.yml
+++ b/assets/docker-compose.yml
@@ -13,18 +13,14 @@ services:
       retries: 5
 
   upstreams:
-    image: rodolpheche/wiremock:2.6.0-alpine
+    image: rodolpheche/wiremock:2.27.1-alpine
     ports:
       - '9089:8080'
-    volumes:
-      - ./stubs/upstreams:/home/wiremock/mappings
 
   auth-service:
-    image: rodolpheche/wiremock:2.6.0-alpine
+    image: rodolpheche/wiremock:2.27.1-alpine
     ports:
       - '9088:8080'
-    volumes:
-      - ./stubs/auth-service:/home/wiremock/mappings
 
   jaeger:
     image: jaegertracing/all-in-one

--- a/build/features.sh
+++ b/build/features.sh
@@ -8,9 +8,14 @@ WARN_COLOR='\033[33;01m'
 PASS="${OK_COLOR}PASS ${NO_COLOR}"
 FAIL="${ERROR_COLOR}FAIL ${NO_COLOR}"
 
+MONGO_PORT="27017"
+if [[ -n "${DYNAMIC_MONGO_PORT}" ]]; then
+    MONGO_PORT=${DYNAMIC_MONGO_PORT}
+fi
+
 echo "${OK_COLOR}Running features test:${NO_COLOR}"
 
-export DATABASE_DSN="mongodb://localhost:27017/ops_gateway"
+export DATABASE_DSN="mongodb://localhost:${MONGO_PORT}/ops_gateway"
 export STATS_DSN="noop://"
 export PORT="3000"
 export API_PORT="3001"
@@ -23,7 +28,7 @@ export PORT_SECONDARY="3100"
 export API_PORT_SECONDARY="3101"
 export BACKEND_UPDATE_FREQUENCY="0.5s"
 
-"./dist/janus" start > /tmp/janus.log 2>&1 &
+"./dist/janus" start >/tmp/janus.log 2>&1 &
 exit_code=$?
 if [ ${exit_code} -ne 0 ]; then
     echo "${ERROR_COLOR}Failed to run primary janus instance${NO_COLOR}"
@@ -43,7 +48,7 @@ API_PORT_PRIMARY=${API_PORT}
 export PORT=${PORT_SECONDARY}
 export API_PORT=${API_PORT_SECONDARY}
 
-"./dist/janus" start > /tmp/janus2.log 2>&1 &
+"./dist/janus" start >/tmp/janus2.log 2>&1 &
 exit_code=$?
 if [ ${exit_code} -ne 0 ]; then
     echo "${ERROR_COLOR}Failed to run secondary janus instance${NO_COLOR}"

--- a/build/mocks.sh
+++ b/build/mocks.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+NO_COLOR='\033[0m'
+OK_COLOR='\033[32;01m'
+ERROR_COLOR='\033[31;01m'
+WARN_COLOR='\033[33;01m'
+
+AUTH_MOCK_PORT="9088"
+if [[ -n "${DYNAMIC_AUTH_MOCK_PORT}" ]]; then
+    AUTH_MOCK_PORT=${DYNAMIC_AUTH_MOCK_PORT}
+fi
+
+UPSTREAMS_MOCK_PORT="9089"
+if [[ -n "${DYNAMIC_UPSTREAMS_MOCK_PORT}" ]]; then
+    UPSTREAMS_MOCK_PORT=${DYNAMIC_UPSTREAMS_MOCK_PORT}
+fi
+
+echo "${OK_COLOR}Uploading auth mock fixture:${NO_COLOR}"
+curl -X DELETE --silent --show-error --fail --output /dev/null "http://localhost:${AUTH_MOCK_PORT}/__admin/mappings"
+for fixture in assets/stubs/auth-service/*; do
+    curl --silent --show-error --fail --output /dev/null "http://localhost:${AUTH_MOCK_PORT}/__admin/mappings" -d "@${fixture}" --header "Content-Type: application/json"
+    echo "Added fixture: ${fixture}"
+done
+
+echo "${OK_COLOR}Uploading upstreams mock fixture:${NO_COLOR}"
+curl -X DELETE --silent --show-error --fail --output /dev/null "http://localhost:${UPSTREAMS_MOCK_PORT}/__admin/mappings"
+for fixture in assets/stubs/upstreams/*; do
+    curl --silent --show-error --fail --output /dev/null "http://localhost:${UPSTREAMS_MOCK_PORT}/__admin/mappings" -d "@${fixture}" --header "Content-Type: application/json"
+    echo "Added fixture: ${fixture}"
+done

--- a/pkg/loader/api_loader_test.go
+++ b/pkg/loader/api_loader_test.go
@@ -64,18 +64,20 @@ func TestSuccessfulLoader(t *testing.T) {
 	defer ts.Close()
 
 	for _, tc := range tests {
-		res, err := ts.Do(tc.method, tc.url, tc.headers)
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			err := res.Body.Close()
-			assert.NoError(t, err)
+		t.Run(tc.description, func(t *testing.T) {
+			res, err := ts.Do(tc.method, tc.url, tc.headers)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				err := res.Body.Close()
+				assert.NoError(t, err)
+			})
+
+			for headerName, headerValue := range tc.expectedHeaders {
+				assert.Equal(t, headerValue, res.Header.Get(headerName))
+			}
+
+			assert.Equal(t, tc.expectedCode, res.StatusCode)
 		})
-
-		for headerName, headerValue := range tc.expectedHeaders {
-			assert.Equal(t, headerValue, res.Header.Get(headerName))
-		}
-
-		assert.Equal(t, tc.expectedCode, res.StatusCode, tc.description)
 	}
 }
 


### PR DESCRIPTION
When running dependencies on non-local docker instance there is no way to mount volumes with mocks. So before running tests bootstrap creates all the mocks with API.

Since port is going to be dynamic - we need to support this thing as well.