### PR TITLE
EES-574 Simplified application build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,18 +3,13 @@ OK_COLOR=\033[32;01m
 ERROR_COLOR=\033[31;01m
 WARN_COLOR=\033[33;01m
 
-# The import path is the unique absolute name of your repository.
-# All subpackages should always be imported as relative to it.
-# If you change this, run `make clean`.
-PKG_SRC := github.com/hellofresh/janus
+.PHONY: all lint test-unit test-integration test-features build
 
-.PHONY: all clean lint test-unit build
-
-all: clean lint test-unit test-integration test-features lint build
+all: test-unit build
 
 build:
 	@echo "$(OK_COLOR)==> Building... $(NO_COLOR)"
-	@/bin/sh -c "JANUS_BUILD_ONLY_DEFAULT=$(JANUS_BUILD_ONLY_DEFAULT) PKG_SRC=$(PKG_SRC) VERSION=$(VERSION) ./build/build.sh"
+	@/bin/sh -c "JANUS_BUILD_ONLY_DEFAULT=$(JANUS_BUILD_ONLY_DEFAULT) VERSION=$(VERSION) ./build/build.sh"
 
 test-unit:
 	@echo "$(OK_COLOR)==> Running unit tests$(NO_COLOR)"
@@ -25,17 +20,12 @@ test-integration: _mocks
 	@go test -cover -tags=integration -coverprofile=coverage.txt -covermode=atomic ./...
 
 test-features: _mocks
-	@/bin/sh -c "JANUS_BUILD_ONLY_DEFAULT=1 PKG_SRC=$(PKG_SRC) ./build/build.sh"
+	@/bin/sh -c "JANUS_BUILD_ONLY_DEFAULT=1 ./build/build.sh"
 	@/bin/sh -c "./build/features.sh"
 
 lint:
 	@echo "$(OK_COLOR)==> Linting with golangci-lint running in docker container$(NO_COLOR)"
 	@docker run --rm -v $(PWD):/app -w /app golangci/golangci-lint:v1.30.0 golangci-lint run -v
-
-clean:
-	@echo "$(OK_COLOR)==> Cleaning project$(NO_COLOR)"
-	@go clean
-	@rm -rf bin $GOPATH/bin
 
 _mocks:
 	@/bin/sh -c "./build/mocks.sh"

--- a/build/build.sh
+++ b/build/build.sh
@@ -7,12 +7,12 @@ rm -f dist/janus*
 
 # Check if VERSION variable set and not empty, otherwise set to default value
 if [ -z "$VERSION" ]; then
-  VERSION="0.0.1-dev"
+    VERSION="0.0.1-dev"
 fi
 echo "Building application version $VERSION"
 
 echo "Building default binary"
-CGO_ENABLED=0 go build -ldflags "-s -w" -ldflags "-X github.com/hellofresh/janus/cmd.version=${VERSION}" -o "dist/janus" $PKG_SRC
+CGO_ENABLED=0 go build -ldflags "-s -w" -ldflags "-X main.version=${VERSION}" -o "dist/janus"
 
 if [ ! -z "${JANUS_BUILD_ONLY_DEFAULT}" ]; then
     echo "Only default binary was requested to build"
@@ -23,18 +23,18 @@ fi
 OS_PLATFORM_ARG=(linux darwin windows freebsd openbsd)
 OS_ARCH_ARG=(386 amd64)
 for OS in ${OS_PLATFORM_ARG[@]}; do
-  for ARCH in ${OS_ARCH_ARG[@]}; do
-    echo "Building binary for $OS/$ARCH..."
-    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w" -ldflags "-X github.com/hellofresh/janus/cmd.version=${VERSION}" -o "dist/janus_$OS-$ARCH" $PKG_SRC
-  done
+    for ARCH in ${OS_ARCH_ARG[@]}; do
+        echo "Building binary for $OS/$ARCH..."
+        GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w" -ldflags "-X main.version=${VERSION}" -o "dist/janus_$OS-$ARCH"
+    done
 done
 
 # Build arm binaries
 OS_PLATFORM_ARG=(linux)
 OS_ARCH_ARG=(arm arm64)
 for OS in ${OS_PLATFORM_ARG[@]}; do
-  for ARCH in ${OS_ARCH_ARG[@]}; do
-    echo "Building binary for $OS/$ARCH..."
-    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w" -ldflags "-X main.version=${VERSION}" -o "dist/janus_$OS-$ARCH" $PKG_SRC
-  done
+    for ARCH in ${OS_ARCH_ARG[@]}; do
+        echo "Building binary for $OS/$ARCH..."
+        GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build -ldflags "-s -w" -ldflags "-X main.version=${VERSION}" -o "dist/janus_$OS-$ARCH"
+    done
 done

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,7 +9,7 @@ import (
 var configFile string
 
 // NewRootCmd creates a new instance of the root command
-func NewRootCmd() *cobra.Command {
+func NewRootCmd(version string) *cobra.Command {
 	ctx := context.Background()
 
 	cmd := &cobra.Command{
@@ -26,8 +26,8 @@ Complete documentation is available at https://hellofresh.gitbooks.io/janus`,
 	cmd.PersistentFlags().StringVarP(&configFile, "config", "c", "", "Config file (default is $PWD/janus.toml)")
 
 	cmd.AddCommand(NewCheckCmd(ctx))
-	cmd.AddCommand(NewVersionCmd(ctx))
-	cmd.AddCommand(NewServerStartCmd(ctx))
+	cmd.AddCommand(NewVersionCmd(ctx, version))
+	cmd.AddCommand(NewServerStartCmd(ctx, version))
 
 	return cmd
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -33,14 +33,14 @@ type ServerStartOptions struct {
 }
 
 // NewServerStartCmd creates a new http server command
-func NewServerStartCmd(ctx context.Context) *cobra.Command {
+func NewServerStartCmd(ctx context.Context, version string) *cobra.Command {
 	opts := &ServerStartOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "start",
 		Short: "Starts a Janus web server",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return RunServerStart(ctx, opts)
+			return RunServerStart(ctx, opts, version)
 		},
 	}
 
@@ -51,7 +51,7 @@ func NewServerStartCmd(ctx context.Context) *cobra.Command {
 }
 
 // RunServerStart is the run command to start Janus
-func RunServerStart(ctx context.Context, opts *ServerStartOptions) error {
+func RunServerStart(ctx context.Context, opts *ServerStartOptions, version string) error {
 	// all the logging configurations are initialised in initLog() later,
 	// but we try to initialise Writer (STDIN/STDERR/etc.) as early as possible manually
 	// to avoid loosing logs in systems heavily relying on them (e.g. running in docker)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,10 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "0.0.0-dev"
-
 // NewVersionCmd creates a new version command
-func NewVersionCmd(ctx context.Context) *cobra.Command {
+func NewVersionCmd(ctx context.Context, version string) *cobra.Command {
 	return &cobra.Command{
 		Use:     "version",
 		Short:   "Print the version information",

--- a/main.go
+++ b/main.go
@@ -7,8 +7,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var version = "0.0.0-dev"
+
 func main() {
-	rootCmd := cmd.NewRootCmd()
+	rootCmd := cmd.NewRootCmd(version)
 
 	if err := rootCmd.Execute(); err != nil {
 		log.WithError(err).Error(err.Error())


### PR DESCRIPTION
## What does this PR do?
- fewer parameters for build
- `make` does not depend on anything except unit-tests (just to ensure), the rest should be executed in testing pipeline before merging/building