### PR TITLE
EES-574 Ignore freebsd/arm64 build as it can not be done

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,6 +22,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: 386
+      - goos: freebsd
+        goarch: arm64
 
 dockers:
   - goos: linux


### PR DESCRIPTION
Adding to ignore because of

```
   ⨯ release failed after 369.34s error=failed to build for freebsd_arm64: # golang.org/x/sys/unix
../../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190825160603-fb81701db80f/unix/ztypes_freebsd_arm64.go:400:12: undefined: uint128
```

All other builds seems yo be working, at least locally.