### PR TITLE
Improve access rule middleware

### DIFF
--- a/pkg/plugin/oauth2/middleware_access_rules.go
+++ b/pkg/plugin/oauth2/middleware_access_rules.go
@@ -30,15 +30,14 @@ func NewRevokeRulesMiddleware(parser *jwt.Parser, accessRules []*AccessRule) fun
 				for _, rule := range accessRules {
 					allowed, err := rule.IsAllowed(claims)
 					if err != nil {
-						log.WithError(err).Debug("Rule is not allowed")
-						continue
-					}
-
-					if allowed {
-						handler.ServeHTTP(w, r)
-					} else {
-						w.WriteHeader(http.StatusUnauthorized)
-						return
+						log.WithError(err).Debug("Rule is invalid")
+					} else if rule.matched {
+						if allowed {
+							break
+						} else {
+							w.WriteHeader(http.StatusUnauthorized)
+							return
+						}
 					}
 				}
 			}

--- a/pkg/plugin/oauth2/oauth.go
+++ b/pkg/plugin/oauth2/oauth.go
@@ -139,6 +139,7 @@ type AccessRule struct {
 	Predicate string `bson:"predicate" json:"predicate"`
 	Action    string `bson:"action" json:"action"`
 	parsed    bool
+	matched   bool
 }
 
 // IsAllowed checks if the rule is allowed to
@@ -146,14 +147,14 @@ func (r *AccessRule) IsAllowed(claims map[string]interface{}) (bool, error) {
 	var err error
 
 	if !r.parsed {
-		matched, err := r.parse(claims)
+		r.matched, err = r.parse(claims)
 		if err != nil {
 			return false, err
 		}
+	}
 
-		if !matched {
-			return true, nil
-		}
+	if !r.matched {
+		return true, nil
 	}
 
 	return r.Action == "allow", err


### PR DESCRIPTION
This PR improves the access rule middleware:
- bugfix: a non-matching deny rule wrongly blocks the request when evaluated a second time
- bugfix: handler function gets executed multiple times when allow rules match
- improvement: do not ignore multiple rules
- housekeeping: simplify tests for access rule middleware